### PR TITLE
Fix error message if role is not found

### DIFF
--- a/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
+++ b/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
@@ -313,7 +313,7 @@ final class OktaAwsCliAssumeRole {
             }
         }
         if (awsRoleToAssume != null && j == -1) {
-            System.out.println("No match for role " + roleArns.get(i));
+            System.out.println("No match for role " + awsRoleToAssume);
         }
 
         // Default to no selection


### PR DESCRIPTION
Problem Statement
-----------------
If role is not found the error message will generate

```
Please choose the role you would like to assume:
Exception in thread "main" java.lang.IndexOutOfBoundsException: Index: 0, Size: 0 
```
The i will have been increased until array size, so the get(i) will always fail

Solution
--------
Just display the searched role from parameter

