### PR TITLE
fixes jar, adds ec to default role

### DIFF
--- a/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
+++ b/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
@@ -313,7 +313,7 @@ final class OktaAwsCliAssumeRole {
             }
         }
         if ((awsRoleToAssume != null && !awsRoleToAssume.isEmpty()) && j == -1) {
-            System.out.println("\ncould not find the role " + awsRoleToAssume + "\n specified in the config.properties file.");
+            System.out.println("No match for role " + awsRoleToAssume);
         }
 
         // Default to no selection

--- a/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
+++ b/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
@@ -312,8 +312,8 @@ final class OktaAwsCliAssumeRole {
                 i++;
             }
         }
-        if (awsRoleToAssume != null && j == -1) {
-            System.out.println("No match for role " + awsRoleToAssume);
+        if ((awsRoleToAssume != null && !awsRoleToAssume.isEmpty()) && j == -1) {
+            System.out.println("\ncould not find the role " + awsRoleToAssume + "\n specified in the config.properties file.");
         }
 
         // Default to no selection


### PR DESCRIPTION
Problem Statement
-----------------
The default jar included in the repo resulted in an unusable UI (role names were listed incorrectly and could not be successfully selected).

Solution
--------
Built a new jar file for inclusion in the /out dir. Also improved error-checking for reading a default role from the config.properties file (now checks for empty string in addition to null).

Before:
<img width="495" alt="before" src="https://user-images.githubusercontent.com/20563254/34422953-ead0c64e-ebe6-11e7-92c5-10617e46af95.png">

After:
<img width="380" alt="after" src="https://user-images.githubusercontent.com/20563254/34422955-efc70b54-ebe6-11e7-9d0e-1bf1af883c30.png">



