### PR TITLE
Menu Selection/Bat File Fixes

### DIFF
--- a/out/awscli.bat
+++ b/out/awscli.bat
@@ -13,4 +13,4 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 rem
-java -classpath .;oktaawscli.jar com.okta.tools.awscli
+java -classpath .;oktaawscli.jar com.okta.tools.awscli %*

--- a/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
+++ b/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
@@ -234,7 +234,7 @@ final class OktaAwsCliAssumeRole {
     }
 
     private int promptForMenuSelection(int max) {
-        if (max == 1) return 1;
+        if (max == 1) return 0;
         Scanner scanner = new Scanner(System.in);
 
         int selection = -1;
@@ -510,7 +510,7 @@ final class OktaAwsCliAssumeRole {
 
         //Handles user factor selection
         int selection = promptForMenuSelection(supportedFactors.size());
-        return supportedFactors.get(selection - 1);
+        return supportedFactors.get(selection);
     }
 
     private List<JSONObject> getUsableFactors(JSONArray factors) {


### PR DESCRIPTION
Problem Statement
-----------------

Current menu selection was broken.
Bat file was not accepting additional arguments (ie: .\awscli.bat s3 ls) would not accept the **s3 ls** args.

Solution
--------

Fixed menu selection, fixed bat file.

