### PR TITLE
BC-ProfileNames

### DIFF
--- a/out/withokta
+++ b/out/withokta
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Copyright 2017 Okta
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+java -classpath .:oktaawscli.jar com.okta.tools.WithOkta $@

--- a/out/withokta.bat
+++ b/out/withokta.bat
@@ -1,0 +1,16 @@
+rem
+rem Copyright 2017 Okta
+rem
+rem Licensed under the Apache License, Version 2.0 (the "License");
+rem you may not use this file except in compliance with the License.
+rem You may obtain a copy of the License at
+rem
+rem     http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing, software
+rem distributed under the License is distributed on an "AS IS" BASIS,
+rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem See the License for the specific language governing permissions and
+rem limitations under the License.
+rem
+java -classpath .;oktaawscli.jar com.okta.tools.WithOkta %*

--- a/src/main/java/com/okta/tools/OktaAwsConfig.java
+++ b/src/main/java/com/okta/tools/OktaAwsConfig.java
@@ -1,0 +1,37 @@
+package com.okta.tools;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Properties;
+
+final class OktaAwsConfig {
+    static OktaAwsCliAssumeRole createAwscli() throws IOException {
+        Properties properties = new Properties();
+        InputStream config;
+        try {
+            config = new FileInputStream("config.properties");
+        } catch (IOException ex) {
+            // Fallback to classpath input stream
+            config = properties.getClass().getResourceAsStream("/config.properties");
+        }
+        properties.load(new InputStreamReader(config));
+
+        return OktaAwsCliAssumeRole.createOktaAwsCliAssumeRole(
+                getEnvOrConfig(properties, "OKTA_ORG"),
+                getEnvOrConfig(properties, "OKTA_AWS_APP_URL"),
+                getEnvOrConfig(properties, "OKTA_USERNAME"),
+                getEnvOrConfig(properties, "OKTA_PASSWORD"),
+                getEnvOrConfig(properties, "OKTA_PROFILE"),
+                getEnvOrConfig(properties, "OKTA_AWS_ROLE_TO_ASSUME")
+
+        );
+    }
+
+    private static String getEnvOrConfig(Properties properties, String propertyName) {
+        String envValue = System.getenv(propertyName);
+        return envValue != null ?
+                envValue : properties.getProperty(propertyName);
+    }
+}

--- a/src/main/java/com/okta/tools/WithOkta.java
+++ b/src/main/java/com/okta/tools/WithOkta.java
@@ -1,0 +1,32 @@
+package com.okta.tools;
+
+import java.time.Instant;
+
+/*
+ * Copyright 2017 Okta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+public class WithOkta {
+    public static void main(String[] args) throws Exception {
+        OktaAwsConfig.createAwscli().run(Instant.now());
+        ProcessBuilder awsProcessBuilder = new ProcessBuilder().inheritIO().command(args);
+        Process awsSubProcess = awsProcessBuilder.start();
+        int exitCode = awsSubProcess.waitFor();
+        System.exit(exitCode);
+    }
+
+}
+

--- a/src/main/java/com/okta/tools/awscli.java
+++ b/src/main/java/com/okta/tools/awscli.java
@@ -15,10 +15,6 @@
  */
 package com.okta.tools;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.time.Instant;
 import java.util.*;
 
@@ -30,7 +26,7 @@ public class awscli {
             System.exit(0);
             return;
         }
-        String profileName = createAwscli().run(Instant.now());
+        String profileName = OktaAwsConfig.createAwscli().run(Instant.now());
         List<String> awsCommand = new ArrayList<>();
         awsCommand.add("aws");
         awsCommand.add("--profile");
@@ -40,31 +36,5 @@ public class awscli {
         Process awsSubProcess = awsProcessBuilder.start();
         int exitCode = awsSubProcess.waitFor();
         System.exit(exitCode);
-    }
-
-    private static OktaAwsCliAssumeRole createAwscli() throws IOException {
-        Properties properties = new Properties();
-        InputStream config;
-        try {
-            config = new FileInputStream("config.properties");
-        } catch (IOException ex) {
-            // Fallback to classpath input stream
-            config = properties.getClass().getResourceAsStream("/config.properties");
         }
-        properties.load(new InputStreamReader(config));
-
-        return OktaAwsCliAssumeRole.createOktaAwsCliAssumeRole(
-                getEnvOrConfig(properties, "OKTA_ORG"),
-                getEnvOrConfig(properties, "OKTA_AWS_APP_URL"),
-                getEnvOrConfig(properties, "OKTA_USERNAME"),
-                getEnvOrConfig(properties, "OKTA_PASSWORD"),
-                getEnvOrConfig(properties, "OKTA_AWS_ROLE_TO_ASSUME")
-        );
-    }
-
-    private static String getEnvOrConfig(Properties properties, String propertyName) {
-        String envValue = System.getenv(propertyName);
-        return envValue != null ?
-                envValue : properties.getProperty(propertyName);
-    }
 }


### PR DESCRIPTION
Problem Statement
-----------------
Cannot make profiles for multiple environments using Okta.


Solution
--------
Added withokta command that takes the environment variable in the shell and creates a profile for it. This command operates like sudo in that it runs the entire command handed to it. This could be used for things like Terraform or Serverless. You could do a command like env OKTA_PROFILE=prod ./withokta aws --profile prod s3 ls.