### PR TITLE
:bug: RSA and Symantec VIP tokens not accepted

### DIFF
--- a/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
+++ b/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
@@ -613,6 +613,7 @@ final class OktaAwsCliAssumeRole {
                     return sessionToken;
 
                 }
+                case ("token"):
                 case ("token:hardware"):
                 case ("token:software:totp"): {
                     //token factor handler
@@ -662,6 +663,7 @@ final class OktaAwsCliAssumeRole {
                 case "sms":
                     factorType = "SMS Authentication";
                     break;
+                case "token":
                 case "token:software:totp":
                     String provider = factor.getString("provider");
                     if (provider.equals("GOOGLE")) {


### PR DESCRIPTION
Problem Statement
-----------------

Symantec VIP and RSA tokens aren't accepted as factors right now.

Solution
--------

Add support for "token" type factors. Fix https://github.com/oktadeveloper/okta-aws-cli-assume-role/issues/74.
