### PR TITLE
Support for AWS Tools for Windows PowerShell

### DIFF
--- a/src/main/java/com/okta/tools/aws/settings/Configuration.java
+++ b/src/main/java/com/okta/tools/aws/settings/Configuration.java
@@ -67,7 +67,7 @@ public class Configuration extends Settings {
 
     private void writeConfigurationProfile(Profile.Section awsProfile, String name, String roleToAssume) {
         awsProfile.put(ROLE_ARN, roleToAssume);
-        awsProfile.put(SOURCE_PROFILE, name);
+        awsProfile.put(SOURCE_PROFILE, name + "_source");
         awsProfile.put(REGION, REGION_DEFAULT);
     }
 }

--- a/src/main/java/com/okta/tools/aws/settings/Credentials.java
+++ b/src/main/java/com/okta/tools/aws/settings/Credentials.java
@@ -51,6 +51,7 @@ public class Credentials extends Settings {
      * @param awsSessionToken The session token to use for the profile.
      */
     public void addOrUpdateProfile(String name, String awsAccessKey, String awsSecretKey, String awsSessionToken) {
+        name = name + "_source";
         final Profile.Section awsProfile = settings.get(name) != null ? settings.get(name) : settings.add(name);
         writeCredentialsProfile(awsProfile, awsAccessKey, awsSecretKey, awsSessionToken);
     }

--- a/src/test/java/com/okta/tools/aws/settings/ConfigurationTest.java
+++ b/src/test/java/com/okta/tools/aws/settings/ConfigurationTest.java
@@ -43,7 +43,7 @@ class ConfigurationTest {
     private String region = "us-east-1";
     private String manualRole = "[profile " + profileName + "]\n"
             + Configuration.ROLE_ARN + " = " + role_arn + "\n"
-            + SOURCE_PROFILE + " = " + profileName + "\n"
+            + SOURCE_PROFILE + " = " + profileName + "_source\n"
             + Configuration.REGION + " = " + region;
 
     /*
@@ -72,7 +72,7 @@ class ConfigurationTest {
         // Write an initial profile. This should create a default profile as well.
         initiallyEmpty.addOrUpdateProfile(profileName, role_arn);
         assertEquals(2, initiallyEmpty.settings.size());
-        assertEquals(profileName, initiallyEmpty.settings.get(DEFAULTPROFILENAME, SOURCE_PROFILE));
+        assertEquals(profileName + "_source", initiallyEmpty.settings.get(DEFAULTPROFILENAME, SOURCE_PROFILE));
         assertEquals(role_arn, initiallyEmpty.settings.get(DEFAULTPROFILENAME, ROLE_ARN));
         // State of the default profile after creating an initial profile.
         final Map<String, String> defaultProfileBefore = sectionToMap.apply(initiallyEmpty.settings.get(DEFAULTPROFILENAME));
@@ -112,7 +112,7 @@ class ConfigurationTest {
         final String updatedPrefix = "updated_";
         final String expected = "[profile " + profileName + "]\n"
                 + Configuration.ROLE_ARN + " = " + updatedPrefix + role_arn + "\n"
-                + SOURCE_PROFILE + " = " + profileName + "\n"
+                + SOURCE_PROFILE + " = " + profileName + "_source\n"
                 + Configuration.REGION + " = " + region
                 + "\n\n" + existingProfile;
 

--- a/src/test/java/com/okta/tools/aws/settings/CredentialsTest.java
+++ b/src/test/java/com/okta/tools/aws/settings/CredentialsTest.java
@@ -32,7 +32,7 @@ class CredentialsTest {
     private String accessKey = "accesskey";
     private String secretKey = "secretkey";
     private String sessionToken = "sessiontoken";
-    private String manualRole = "[" + roleName + "]\n"
+    private String manualRole = "[" + roleName + "_source]\n"
             + Credentials.ACCES_KEY_ID + " = " + accessKey + "\n"
             + Credentials.SECRET_ACCESS_KEY + " = " + secretKey + "\n"
             + Credentials.SESSION_TOKEN + " = " + sessionToken;
@@ -86,7 +86,7 @@ class CredentialsTest {
 
         final String updatedPrefix = "updated_";
         final String expected = existingCredentials + "\n\n"
-                + "[" + roleName + "]\n"
+                + "[" + roleName + "_source]\n"
                 + Credentials.ACCES_KEY_ID + " = " + updatedPrefix + accessKey + "\n"
                 + Credentials.SECRET_ACCESS_KEY + " = " + updatedPrefix + secretKey + "\n"
                 + Credentials.SESSION_TOKEN + " = " + updatedPrefix + sessionToken;


### PR DESCRIPTION
Problem Statement
-----------------

Attempting to use **withokta** with a named profile and PowerShell downstream leads to an error like this:
```powershell
Credential profile [Corp] is not valid.  Please ensure the profile contains a valid combination of properties.
```

Solution
--------

Use a distinct name for the source_profile saved to ~/.aws/credentials. This works for PowerShell, AWS CLI, Python programs using boto3, and AWS SDK for Java. It likely works for other AWS SDKs as well.
