### PR TITLE
Reusing Okta Session ID

### DIFF
--- a/src/main/java/com/okta/tools/WithOkta.java
+++ b/src/main/java/com/okta/tools/WithOkta.java
@@ -26,5 +26,4 @@ public class WithOkta {
         int exitCode = awsSubProcess.waitFor();
         System.exit(exitCode);
     }
-
 }

--- a/src/main/java/com/okta/tools/aws/settings/MultipleProfile.java
+++ b/src/main/java/com/okta/tools/aws/settings/MultipleProfile.java
@@ -21,6 +21,7 @@ import org.ini4j.Profile;
 import java.io.*;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.Set;
 
 public class MultipleProfile extends Settings {
@@ -29,16 +30,16 @@ public class MultipleProfile extends Settings {
     static final String PROFILE_EXPIRY = "profile_expiry";
     static final String OKTA_SESSION = "okta_roleArn";
 
-    public com.okta.tools.aws.settings.Profile getProfile(String oktaprofile, Path profileIni) throws IOException {
+    public Optional<com.okta.tools.aws.settings.Profile> getProfile(String oktaprofile, Path profileIni) throws IOException {
 
         Ini ini = new Ini(new File(profileIni.toString()));
         Set<String> activeSessions = ini.keySet();
         if (activeSessions.contains(oktaprofile)) {
             Instant expiry = getExpiry(oktaprofile, ini);
             String roleArn = getRoleArn(oktaprofile, ini);
-            return new com.okta.tools.aws.settings.Profile(expiry, roleArn);
+            return Optional.of(new com.okta.tools.aws.settings.Profile(expiry, roleArn));
         }
-        return null;
+        return Optional.empty();
     }
     public void deleteProfile(String profilestore, String oktaProfile) throws IOException {
         try ( FileInputStream is = new FileInputStream(new File(profilestore))) {
@@ -55,8 +56,8 @@ public class MultipleProfile extends Settings {
     }
 
     private String getRoleArn(String oktaprofile, Ini ini) {
-        Ini.Section profilesection = ini.get(oktaprofile);
-        String roleArn = profilesection.get("okta_expiry");
+        Ini.Section profileSection = ini.get(oktaprofile);
+        String roleArn = profileSection.get("okta_roleArn");
         return roleArn;
     }
 


### PR DESCRIPTION
Problem Statement
-----------------
It is required that MFA must be used every time a new profile is made or refreshed.


Solution
--------
The Session ID cookie is saved and reused so that the session will refresh as long as the session is still valid.

