### PR TITLE
:art: Avoid including accidental build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ out/config.properties
 
 target/classes/log4j2.xml
 /target/
+/out/oktaawscli.jar
 .classpath
 .settings
 .project


### PR DESCRIPTION
Problem Statement
-----------------

People may accidentally include oktaawscli.jar in their PRs following the old process.

Solution
--------

Ignore oktaawscli.jar.