### PR TITLE
:bug: :memo: Fix #30 by removing macOS reference

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -86,7 +86,6 @@ __Important note__: please note that this tool only supports Okta MFA set up at 
 ## Setup
 
 - Use ```git clone https://github.com/oktadeveloper/okta-aws-cli-assume-role.git``` to clone the repository locally.
-- In Terminal, run ```defaults write com.apple.finder AppleShowAllFiles YES``` if you want to be able to inspect the ```~/.aws/credentials``` and ```~/.aws/config``` files.
 
 ## Build and run
 


### PR DESCRIPTION
Problem Statement
-----------------

macOS-specific commands referenced in README without clarification.

Solution
--------

Remove references. Clarifying or providing multi-platform answers to this is tangly and better addressed in AWS' own docs.
