### PR TITLE
:bug: Fix #46 by reusing existing region

### DIFF
--- a/src/main/java/com/okta/tools/aws/settings/Configuration.java
+++ b/src/main/java/com/okta/tools/aws/settings/Configuration.java
@@ -68,6 +68,8 @@ public class Configuration extends Settings {
     private void writeConfigurationProfile(Profile.Section awsProfile, String name, String roleToAssume) {
         awsProfile.put(ROLE_ARN, roleToAssume);
         awsProfile.put(SOURCE_PROFILE, name + "_source");
-        awsProfile.put(REGION, REGION_DEFAULT);
+        if (!awsProfile.containsKey(REGION)) {
+            awsProfile.put(REGION, REGION_DEFAULT);
+        }
     }
 }


### PR DESCRIPTION
Problem Statement
-----------------

The profile management introduced in #81 (merged to master) overwrites the region in ~/.aws/config.

Solution
--------

If profile in ~/.aws/config has region set, leave it as is.
