### PR TITLE
:seedling: Install-friendly config and scripts

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -4,6 +4,33 @@ This readme file is an excerpt of the [Okta-AWS Integration Guide](https://suppo
 
 Important Note: This tool has been verified to work on Mac OS X El Capitan and Windows Server 2012 R2 and is expected to work on Linux and Unix as well.
 
+## Installation
+
+Create a **~/.okta/** directory and put the JAR in there.
+
+Download the latest release JAR and put it in **~/.okta/**:
+https://github.com/oktadeveloper/okta-aws-cli-assume-role/releases
+
+Copy **config.properties** to **~/.okta/config.properties** and set
+**OKTA_ORG** and **OKTA_AWS_APP_URL** appropriately.
+
+Copy scripts from **bin** to somewhere on your **PATH**. 
+
+Verify your setup with a simple command:
+
+```bash
+awscli sts get-caller-identity
+```
+
+You should see a username and password prompt and (optionally) an MFA
+prompt if you require it.
+
+If you have a single AWS role assigned in the Okta AWS app, the command
+`aws sts get-caller-identity` will run with that role at this point.
+
+If you multiple AWS roles assigned in the Okta AWS app, you will be
+presented with a role-selection menu and then your command will run.
+
 ### Wrap AWS CLI with session resumption (2017/12/5 update)
 Stored IAM credentials are no longer used: you no longer need to distribute or rotate these credentials.
 

--- a/bin/awscli
+++ b/bin/awscli
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Copyright 2017 Okta
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+java -classpath ~/.okta/*.jar com.okta.tools.awscli $@

--- a/bin/awscli.bat
+++ b/bin/awscli.bat
@@ -1,0 +1,16 @@
+rem
+rem Copyright 2017 Okta
+rem
+rem Licensed under the Apache License, Version 2.0 (the "License");
+rem you may not use this file except in compliance with the License.
+rem You may obtain a copy of the License at
+rem
+rem     http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing, software
+rem distributed under the License is distributed on an "AS IS" BASIS,
+rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem See the License for the specific language governing permissions and
+rem limitations under the License.
+rem
+java -classpath "%USERPROFILE%\.okta\*" com.okta.tools.awscli %*

--- a/bin/withokta
+++ b/bin/withokta
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Copyright 2017 Okta
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+java -classpath ~/.okta/*.jar com.okta.tools.WithOkta $@

--- a/bin/withokta.bat
+++ b/bin/withokta.bat
@@ -1,0 +1,16 @@
+rem
+rem Copyright 2017 Okta
+rem
+rem Licensed under the Apache License, Version 2.0 (the "License");
+rem you may not use this file except in compliance with the License.
+rem You may obtain a copy of the License at
+rem
+rem     http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing, software
+rem distributed under the License is distributed on an "AS IS" BASIS,
+rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem See the License for the specific language governing permissions and
+rem limitations under the License.
+rem
+java -classpath "%USERPROFILE%\.okta\*" com.okta.tools.WithOkta %*

--- a/src/main/java/com/okta/tools/OktaAwsConfig.java
+++ b/src/main/java/com/okta/tools/OktaAwsConfig.java
@@ -1,22 +1,25 @@
 package com.okta.tools;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
 import java.util.Properties;
 
 final class OktaAwsConfig {
-    static OktaAwsCliAssumeRole createAwscli() throws IOException {
+
+    private static final String CONFIG_FILENAME = "config.properties";
+
+    static OktaAwsCliAssumeRole createAwscli() {
         Properties properties = new Properties();
-        InputStream config;
-        try {
-            config = new FileInputStream("config.properties");
-        } catch (IOException ex) {
-            // Fallback to classpath input stream
-            config = properties.getClass().getResourceAsStream("/config.properties");
-        }
-        properties.load(new InputStreamReader(config));
+        getConfigFile().ifPresent(configFile -> {
+            try (InputStream config = new FileInputStream(configFile.toFile())) {
+                properties.load(new InputStreamReader(config));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
 
         return OktaAwsCliAssumeRole.createOktaAwsCliAssumeRole(
                 getEnvOrConfig(properties, "OKTA_ORG"),
@@ -27,6 +30,21 @@ final class OktaAwsConfig {
                 getEnvOrConfig(properties, "OKTA_AWS_ROLE_TO_ASSUME")
 
         );
+    }
+
+    private static Optional<Path> getConfigFile()
+    {
+        Path configInWorkingDir = Paths.get(CONFIG_FILENAME);
+        if (Files.isRegularFile(configInWorkingDir)) {
+            return Optional.of(configInWorkingDir);
+        }
+        Path userHome = Paths.get(System.getProperty("user.home"));
+        Path oktaDir = userHome.resolve(".okta");
+        Path configInOktaDir = oktaDir.resolve(CONFIG_FILENAME);
+        if (Files.isRegularFile(configInOktaDir)) {
+            return Optional.of(configInOktaDir);
+        }
+        return Optional.empty();
     }
 
     private static String getEnvOrConfig(Properties properties, String propertyName) {


### PR DESCRIPTION
Problem Statement
-----------------

Issue #88 highlights that forcing config.properties to be in the working directory makes this difficult to roll out or install.

Solution
--------

 - Allow use with config.properties in current working directory

 - Allow use with just environment variables and no config.properties
 
 - Add scripts that work anywhere on **PATH** as long as JAR is in ~/.okta/
