### PR TITLE
:bug: NPE on second run with no profile name

### DIFF
--- a/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
+++ b/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
@@ -106,7 +106,7 @@ final class OktaAwsCliAssumeRole {
         Optional<Profile> profile = multipleProfile.getProfile(oktaProfile, multiprofile);
         awsRoleToAssume = profile.map(profile1 -> profile1.roleArn).orElse(null);
 
-        if (session.isPresent() && sessionIsActive(startInstant, session.get()) && oktaProfile.isEmpty())
+        if (session.isPresent() && sessionIsActive(startInstant, session.get()) && StringUtils.isBlank(oktaProfile))
             return session.get().profileName;
         String samlResponse = getSamlResponse();
         AssumeRoleWithSAMLRequest assumeRequest = chooseAwsRoleToAssume(samlResponse);


### PR DESCRIPTION
 - Allow profile name to be null again

 - Use auto-generated session if named profile is blank or null

Fix #94
Fix #95

Problem Statement
-----------------



Solution
--------


