### PR TITLE
:art: Remove debugging output during auth flow

### DIFF
--- a/src/main/java/com/okta/tools/helpers/RoleHelper.java
+++ b/src/main/java/com/okta/tools/helpers/RoleHelper.java
@@ -53,8 +53,6 @@ public class RoleHelper {
             List<AccountOption> accountOptions = getAvailableRoles(samlResponse);
 
             System.out.println("\nPlease choose the role you would like to assume: ");
-            System.out.println(roleIdpPairs.toString());
-            System.out.println(accountOptions.toString());
             //Gather list of applicable AWS roles
             int i = 0;
             int j = -1;


### PR DESCRIPTION
Problem Statement
-----------------
Debugging output is printed on the console during login. This clutters the output and confuses users.

Solution
--------
Don't show the debugging output.