### PR TITLE
:seedling: Browser-based authentication

### DIFF
--- a/src/main/java/com/okta/tools/BrowserAuthentication.java
+++ b/src/main/java/com/okta/tools/BrowserAuthentication.java
@@ -1,0 +1,105 @@
+package com.okta.tools;
+
+import javafx.application.Application;
+import javafx.concurrent.Worker.State;
+import javafx.scene.Group;
+import javafx.scene.Scene;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
+import javafx.stage.Stage;
+import org.apache.commons.lang.StringUtils;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.CookieHandler;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+
+public class BrowserAuthentication extends Application {
+    private static final String CONFIG_FILENAME = "config.properties";
+
+    @Override
+    public void start(final Stage stage) throws IOException {
+        stage.setWidth(802);
+        stage.setHeight(650);
+        Scene scene = new Scene(new Group());
+
+
+        final WebView browser = new WebView();
+        final WebEngine webEngine = browser.getEngine();
+
+        ScrollPane scrollPane = new ScrollPane();
+        scrollPane.setContent(browser);
+        Properties properties = new Properties();
+        getConfigFile().ifPresent(configFile -> {
+            try (InputStream config = new FileInputStream(configFile.toFile())) {
+                properties.load(new InputStreamReader(config));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        URI uri = URI.create(getEnvOrConfig(properties, "OKTA_AWS_APP_URL"));
+        Map<String, List<String>> headers = new LinkedHashMap<>();
+        java.net.CookieHandler.getDefault().put(uri, headers);
+
+        webEngine.getLoadWorker().stateProperty()
+                .addListener((ov, oldState, newState) -> {
+                    if (newState == State.SUCCEEDED) {
+                        if (webEngine.getLocation().endsWith("/sso/saml")) {
+                            String samlResponse = webEngine.getDocument().getElementsByTagName("input").item(0)
+                                    .getAttributes().getNamedItem("value").getTextContent();
+                            System.out.println(samlResponse);
+                            try {
+                                String cookie = CookieHandler.getDefault().get(uri, headers).get("Cookie").get(0);
+                                String sid = StringUtils.substringBefore(
+                                        StringUtils.substringAfter(cookie, "sid="),
+                                        ";"
+                                );
+                                System.out.println(sid);
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            } finally {
+                                stage.close();
+                            }
+                        }
+                        stage.setTitle(webEngine.getLocation());
+                    }
+                });
+        webEngine.load(uri.toASCIIString());
+
+        scene.setRoot(scrollPane);
+
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    private static Optional<Path> getConfigFile() {
+        Path configInWorkingDir = Paths.get(CONFIG_FILENAME);
+        if (Files.isRegularFile(configInWorkingDir)) {
+            return Optional.of(configInWorkingDir);
+        }
+        Path userHome = Paths.get(System.getProperty("user.home"));
+        Path oktaDir = userHome.resolve(".okta");
+        Path configInOktaDir = oktaDir.resolve(CONFIG_FILENAME);
+        if (Files.isRegularFile(configInOktaDir)) {
+            return Optional.of(configInOktaDir);
+        }
+        return Optional.empty();
+    }
+
+    private static String getEnvOrConfig(Properties properties, String propertyName) {
+        String envValue = System.getenv(propertyName);
+        return envValue != null ?
+                envValue : properties.getProperty(propertyName);
+    }
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+}

--- a/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
+++ b/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
@@ -48,12 +48,12 @@ final class OktaAwsCliAssumeRole {
     private Optional<Session> currentSession;
     private Optional<Profile> currentProfile;
 
-    static OktaAwsCliAssumeRole createOktaAwsCliAssumeRole(String oktaOrg, String oktaAWSAppURL, String oktaAWSUsername, String oktaAWSPassword, String oktaProfile, String oktaAWSRoleToAssume) {
-        return new OktaAwsCliAssumeRole(oktaOrg, oktaAWSAppURL, oktaAWSUsername, oktaAWSPassword, oktaProfile, oktaAWSRoleToAssume);
+    static OktaAwsCliAssumeRole withEnvironment(OktaAwsCliEnvironment environment) {
+        return new OktaAwsCliAssumeRole(environment);
     }
 
-    private OktaAwsCliAssumeRole(String oktaOrg, String oktaAWSAppURL, String oktaUsername, String oktaAWSPassword, String oktaProfile, String awsRoleToAssume) {
-        environment = new OktaAwsCliEnvironment(oktaOrg, oktaUsername, oktaAWSPassword, oktaProfile, oktaAWSAppURL, awsRoleToAssume);
+    private OktaAwsCliAssumeRole(OktaAwsCliEnvironment environment) {
+        this.environment = environment;
     }
 
     private void init() throws Exception {

--- a/src/main/java/com/okta/tools/OktaAwsCliEnvironment.java
+++ b/src/main/java/com/okta/tools/OktaAwsCliEnvironment.java
@@ -1,17 +1,19 @@
 package com.okta.tools;
 
 public class OktaAwsCliEnvironment {
-    public String oktaOrg;
-    public String oktaUsername;
-    public String oktaPassword;
+    public final boolean browserAuth;
+    public final String oktaOrg;
+    public final String oktaUsername;
+    public final String oktaPassword;
     public String oktaProfile;
 
-    public String oktaAwsAppUrl;
+    public final String oktaAwsAppUrl;
 
     public String awsRoleToAssume;
 
-    public OktaAwsCliEnvironment(String oktaOrg, String oktaUsername, String oktaPassword, String oktaProfile,
+    public OktaAwsCliEnvironment(boolean browserAuth, String oktaOrg, String oktaUsername, String oktaPassword, String oktaProfile,
                                  String oktaAwsAppUrl, String awsRoleToAssume) {
+        this.browserAuth = browserAuth;
         this.oktaOrg = oktaOrg;
         this.oktaUsername = oktaUsername;
         this.oktaPassword = oktaPassword;

--- a/src/main/java/com/okta/tools/OktaAwsConfig.java
+++ b/src/main/java/com/okta/tools/OktaAwsConfig.java
@@ -14,7 +14,7 @@ final class OktaAwsConfig {
 
     private static final String CONFIG_FILENAME = "config.properties";
 
-    static OktaAwsCliAssumeRole createAwscli() {
+    static OktaAwsCliEnvironment loadEnvironment() {
         Properties properties = new Properties();
         getConfigFile().ifPresent(configFile -> {
             try (InputStream config = new FileInputStream(configFile.toFile())) {
@@ -24,14 +24,14 @@ final class OktaAwsConfig {
             }
         });
 
-        return OktaAwsCliAssumeRole.createOktaAwsCliAssumeRole(
+        return new OktaAwsCliEnvironment(
+                Boolean.valueOf(getEnvOrConfig(properties, "OKTA_BROWSER_AUTH")),
                 getEnvOrConfig(properties, "OKTA_ORG"),
-                getEnvOrConfig(properties, "OKTA_AWS_APP_URL"),
                 getEnvOrConfig(properties, "OKTA_USERNAME"),
                 getEnvOrConfig(properties, "OKTA_PASSWORD"),
                 getEnvOrConfig(properties, "OKTA_PROFILE"),
+                getEnvOrConfig(properties, "OKTA_AWS_APP_URL"),
                 getEnvOrConfig(properties, "OKTA_AWS_ROLE_TO_ASSUME")
-
         );
     }
 

--- a/src/main/java/com/okta/tools/WithOkta.java
+++ b/src/main/java/com/okta/tools/WithOkta.java
@@ -20,7 +20,7 @@ import java.time.Instant;
 
 public class WithOkta {
     public static void main(String[] args) throws Exception {
-        OktaAwsConfig.createAwscli().run(Instant.now());
+        OktaAwsCliAssumeRole.withEnvironment(OktaAwsConfig.loadEnvironment()).run(Instant.now());
         ProcessBuilder awsProcessBuilder = new ProcessBuilder().inheritIO().command(args);
         Process awsSubProcess = awsProcessBuilder.start();
         int exitCode = awsSubProcess.waitFor();

--- a/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
+++ b/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
@@ -153,6 +153,6 @@ public final class BrowserAuthentication extends Application {
 
     private CookieStore extractCookies(URI uri, Map<String, List<String>> headers) throws IOException {
         List<String> cookieHeaders = CookieHandler.getDefault().get(uri, headers).get("Cookie");
-        return CookieHelper.parseCookies(uri, cookieHeaders);
+        return CookieHelper.parseCookies(cookieHeaders);
     }
 }

--- a/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
+++ b/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
@@ -2,6 +2,7 @@ package com.okta.tools.authentication;
 
 import com.okta.tools.OktaAwsCliEnvironment;
 import com.okta.tools.helpers.CookieHelper;
+import com.okta.tools.util.NodeListIterable;
 import javafx.application.Application;
 import javafx.concurrent.Worker.State;
 import javafx.scene.Group;
@@ -10,12 +11,19 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
-import org.apache.commons.lang.StringUtils;
+import org.apache.http.client.CookieStore;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
-import java.io.*;
+import javax.annotation.Nonnull;
+import java.io.IOException;
 import java.net.CookieHandler;
 import java.net.URI;
-import java.util.*;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -58,25 +66,7 @@ public final class BrowserAuthentication extends Application {
         webEngine.getLoadWorker().stateProperty()
                 .addListener((ov, oldState, newState) -> {
                     if (newState == State.SUCCEEDED) {
-                        if (webEngine.getLocation().endsWith("/sso/saml")) {
-                            samlResponse.set(webEngine.getDocument().getElementsByTagName("input").item(0)
-                                    .getAttributes().getNamedItem("value").getTextContent());
-                            try {
-                                String cookie = CookieHandler.getDefault().get(uri, headers).get("Cookie").get(0);
-                                String sid = StringUtils.substringBefore(
-                                        StringUtils.substringAfter(cookie, "sid="),
-                                        ";"
-                                );
-                                Properties properties = new Properties();
-                                properties.setProperty("sid", sid);
-                                properties.store(new FileWriter(CookieHelper.getCookies().toFile()), "");
-                            } catch (IOException e) {
-                                throw new RuntimeException(e);
-                            } finally {
-                                stage.close();
-                                USER_AUTH_COMPLETE.countDown();
-                            }
-                        }
+                        checkForAwsSamlSignon(stage, webEngine, uri, headers);
                         stage.setTitle(webEngine.getLocation());
                     }
                 });
@@ -86,5 +76,83 @@ public final class BrowserAuthentication extends Application {
 
         stage.setScene(scene);
         stage.show();
+    }
+
+    private void checkForAwsSamlSignon(Stage stage, WebEngine webEngine, URI uri, Map<String, List<String>> headers) {
+        String samlResponseForAws = getSamlResponseForAws(webEngine.getDocument());
+        if (samlResponseForAws != null) {
+            finishAuthentication(stage, uri, headers, samlResponseForAws);
+        }
+    }
+
+    private String getSamlResponseForAws(Document document) {
+        Node awsStsSamlForm = getAwsStsSamlForm(document);
+        if (awsStsSamlForm == null) return null;
+        return getSamlResponseFromForm(awsStsSamlForm);
+    }
+
+    private Node getAwsStsSamlForm(Document document) {
+        NodeList formNodes = document.getElementsByTagName("form");
+        for (Node form : new NodeListIterable(formNodes)) {
+            NamedNodeMap formAttributes = form.getAttributes();
+            if (formAttributes == null) continue;
+            Node formActionAttribute = formAttributes.getNamedItem("action");
+            if (formActionAttribute == null) continue;
+            String formAction = formActionAttribute.getTextContent();
+            if ("https://signin.aws.amazon.com/saml".equals(formAction)) {
+                return form;
+            }
+        }
+        return null;
+    }
+
+    private String getSamlResponseFromForm(@Nonnull Node awsStsSamlForm) {
+        Node samlResponseInput = getSamlResponseInput(awsStsSamlForm);
+        if (samlResponseInput == null)
+            throw new IllegalStateException("Request to AWS STS SAML endpoint missing SAMLResponse");
+        NamedNodeMap attributes = samlResponseInput.getAttributes();
+        Node value = attributes.getNamedItem("value");
+        return value.getTextContent();
+    }
+
+    private Node getSamlResponseInput(@Nonnull Node parent) {
+        for (Node child : new NodeListIterable(parent.getChildNodes())) {
+            if (isSamlResponseInput(child)) {
+                return child;
+            } else {
+                Node samlResponseInput = getSamlResponseInput(child);
+                if (samlResponseInput != null) return samlResponseInput;
+            }
+        }
+        return null;
+    }
+
+    private boolean isSamlResponseInput(@Nonnull Node child) {
+        boolean isInput = "input".equals(child.getLocalName());
+        if (!isInput) return false;
+        NamedNodeMap attributes = child.getAttributes();
+        if (attributes == null) return false;
+        Node nameAttribute = attributes.getNamedItem("name");
+        if (nameAttribute == null) return false;
+        String name = nameAttribute.getTextContent();
+        return "SAMLResponse".equals(name);
+    }
+
+    private void finishAuthentication(Stage stage, URI uri, Map<String, List<String>> headers, String samlResponseForAws) {
+        samlResponse.set(samlResponseForAws);
+        try {
+            CookieStore cookieStore = extractCookies(uri, headers);
+            CookieHelper.storeCookies(cookieStore);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            stage.close();
+            USER_AUTH_COMPLETE.countDown();
+        }
+    }
+
+    private CookieStore extractCookies(URI uri, Map<String, List<String>> headers) throws IOException {
+        List<String> cookieHeaders = CookieHandler.getDefault().get(uri, headers).get("Cookie");
+        return CookieHelper.parseCookies(uri, cookieHeaders);
     }
 }

--- a/src/main/java/com/okta/tools/awscli.java
+++ b/src/main/java/com/okta/tools/awscli.java
@@ -23,14 +23,14 @@ import java.util.List;
 public class awscli {
     public static void main(String[] args) throws Exception {
         if (args.length > 0 && "logout".equals(args[0])) {
-            OktaAwsConfig.createAwscli().logoutSession();
+            OktaAwsCliAssumeRole.withEnvironment(OktaAwsConfig.loadEnvironment()).logoutSession();
             System.out.println("You have been logged out");
             System.exit(0);
             return;
         }
 
         List<String> awsCommand = new ArrayList<>();
-        String profileName = OktaAwsConfig.createAwscli().run(Instant.now());
+        String profileName = OktaAwsCliAssumeRole.withEnvironment(OktaAwsConfig.loadEnvironment()).run(Instant.now());
         awsCommand.add("aws");
         awsCommand.add("--profile");
         awsCommand.add(profileName);

--- a/src/main/java/com/okta/tools/helpers/CookieHelper.java
+++ b/src/main/java/com/okta/tools/helpers/CookieHelper.java
@@ -1,10 +1,25 @@
 package com.okta.tools.helpers;
 
+import com.okta.tools.OktaAwsCliEnvironment;
+import org.apache.http.client.CookieStore;
+import org.apache.http.cookie.*;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.cookie.BasicClientCookie;
+import org.apache.http.impl.cookie.DefaultCookieSpec;
+import org.apache.http.message.BasicHeader;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
 
-public class CookieHelper {
+public final class CookieHelper {
 
     /**
      * Get the path for the cookies file
@@ -12,7 +27,7 @@ public class CookieHelper {
      * @return A {@link Path} to the cookies.properties file
      * @throws IOException
      */
-    public static Path getCookies() throws IOException {
+    private static Path getCookiesFilePath() throws IOException {
         Path filePath = FileHelper.getFilePath(FileHelper.getOktaDirectory(), "cookies.properties");
 
         if (!Files.exists(filePath)) {
@@ -20,5 +35,50 @@ public class CookieHelper {
         }
 
         return filePath;
+    }
+
+    // SOURCE: https://stackoverflow.com/a/13104873/154527
+    // SOURCE: https://github.com/droidparts/droidparts/blob/master/droidparts/src/org/droidparts/net/http/CookieJar.java
+    public static CookieStore parseCookies(URI uri, List<String> cookieHeaders) {
+        CookieSpec cookieSpec = new DefaultCookieSpec();
+        CookieStore cookieStore = new BasicCookieStore();
+        int port = (uri.getPort() < 0) ? 80 : uri.getPort();
+        boolean secure = "https".equals(uri.getScheme());
+        CookieOrigin origin = new CookieOrigin(uri.getHost(), port,
+                uri.getPath(), secure);
+        for (String cookieHeader : cookieHeaders) {
+            BasicHeader header = new BasicHeader(SM.SET_COOKIE, cookieHeader);
+            try {
+                cookieSpec.parse(header, origin).forEach(cookieStore::addCookie);
+            } catch (MalformedCookieException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return cookieStore;
+    }
+
+    public static CookieStore loadCookies(OktaAwsCliEnvironment environment) throws IOException {
+        CookieStore cookieStore = new BasicCookieStore();
+        Properties loadedProperties = new Properties();
+        loadedProperties.load(new FileReader(getCookiesFilePath().toFile()));
+        loadedProperties.entrySet().stream().map(entry -> {
+            BasicClientCookie basicClientCookie = new BasicClientCookie(entry.getKey().toString(), entry.getValue().toString());
+            basicClientCookie.setDomain(environment.oktaOrg);
+
+            return basicClientCookie;
+        }).forEach(cookieStore::addCookie);
+        return cookieStore;
+    }
+
+    public static void storeCookies(CookieStore cookieStore) throws IOException {
+        Properties properties = new Properties();
+        cookieStore.getCookies().stream().collect(Collectors.toMap(Cookie::getName, Cookie::getValue))
+                .forEach(properties::setProperty);
+        properties.store(new FileWriter(getCookiesFilePath().toFile()), "");
+    }
+
+    static void clearCookies() throws IOException {
+        File cookieStore = getCookiesFilePath().toFile();
+        cookieStore.deleteOnExit();
     }
 }

--- a/src/main/java/com/okta/tools/helpers/SessionHelper.java
+++ b/src/main/java/com/okta/tools/helpers/SessionHelper.java
@@ -96,8 +96,7 @@ public final class SessionHelper {
     }
 
     private void logoutMultipleAccounts(String profileName) throws IOException {
-        File cookieStore = CookieHelper.getCookies().toFile();
-        cookieStore.deleteOnExit();
+        CookieHelper.clearCookies();
 
         getMultipleProfile().deleteProfile(getMultipleProfilesPath().toString(), profileName);
     }

--- a/src/main/java/com/okta/tools/saml/OktaSaml.java
+++ b/src/main/java/com/okta/tools/saml/OktaSaml.java
@@ -1,5 +1,6 @@
 package com.okta.tools.saml;
 
+import com.okta.tools.BrowserAuthentication;
 import com.okta.tools.OktaAwsCliEnvironment;
 import com.okta.tools.authentication.OktaAuthentication;
 import com.okta.tools.helpers.CookieHelper;
@@ -39,11 +40,18 @@ public class OktaSaml {
     public String getSamlResponse() throws IOException {
         authentication = new OktaAuthentication(environment);
 
-        if (!reuseSession()) {
+        if (reuseSession()) {
+            return getSamlResponseForAwsRefresh();
+        } else if (environment.browserAuth) {
+            try {
+                BrowserAuthentication.login(environment);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            return getSamlResponseForAwsRefresh();
+        } else {
             String oktaSessionToken = authentication.getOktaSessionToken();
             return getSamlResponseForAws(oktaSessionToken);
-        } else {
-            return getSamlResponseForAwsRefresh();
         }
     }
 

--- a/src/main/java/com/okta/tools/saml/OktaSaml.java
+++ b/src/main/java/com/okta/tools/saml/OktaSaml.java
@@ -1,6 +1,6 @@
 package com.okta.tools.saml;
 
-import com.okta.tools.BrowserAuthentication;
+import com.okta.tools.authentication.BrowserAuthentication;
 import com.okta.tools.OktaAwsCliEnvironment;
 import com.okta.tools.authentication.OktaAuthentication;
 import com.okta.tools.helpers.CookieHelper;
@@ -44,11 +44,10 @@ public class OktaSaml {
             return getSamlResponseForAwsRefresh();
         } else if (environment.browserAuth) {
             try {
-                BrowserAuthentication.login(environment);
+                return BrowserAuthentication.login(environment);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
-            return getSamlResponseForAwsRefresh();
         } else {
             String oktaSessionToken = authentication.getOktaSessionToken();
             return getSamlResponseForAws(oktaSessionToken);

--- a/src/main/java/com/okta/tools/saml/OktaSaml.java
+++ b/src/main/java/com/okta/tools/saml/OktaSaml.java
@@ -10,35 +10,27 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.cookie.Cookie;
-import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.apache.http.impl.cookie.BasicClientCookie;
 import org.json.JSONException;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
 
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
-import java.util.Properties;
-import java.util.stream.Collectors;
 
 public class OktaSaml {
 
     private OktaAwsCliEnvironment environment;
-
-    private OktaAuthentication authentication;
 
     public OktaSaml(OktaAwsCliEnvironment environment) {
         this.environment = environment;
     }
 
     public String getSamlResponse() throws IOException {
-        authentication = new OktaAuthentication(environment);
+        OktaAuthentication authentication = new OktaAuthentication(environment);
 
         if (reuseSession()) {
             return getSamlResponseForAwsRefresh();
@@ -77,17 +69,8 @@ public class OktaSaml {
     }
 
     private Document launchOktaAwsApp(String appUrl) throws IOException {
-        CookieStore cookieStore = new BasicCookieStore();
-        Properties loadedProperties = new Properties();
-
         HttpGet httpget = new HttpGet(appUrl);
-        loadedProperties.load(new FileReader(CookieHelper.getCookies().toFile()));
-        loadedProperties.entrySet().stream().map(entry -> {
-            BasicClientCookie basicClientCookie = new BasicClientCookie(entry.getKey().toString(), entry.getValue().toString());
-            basicClientCookie.setDomain(environment.oktaOrg);
-
-            return basicClientCookie;
-        }).forEach(cookieStore::addCookie);
+        CookieStore cookieStore = CookieHelper.loadCookies(environment);
 
         try (CloseableHttpClient httpClient = HttpClients.custom().setDefaultCookieStore(cookieStore).useSystemProperties().build();
              CloseableHttpResponse oktaAwsAppResponse = httpClient.execute(httpget)) {
@@ -100,10 +83,7 @@ public class OktaSaml {
                         + oktaAwsAppResponse.getStatusLine().getStatusCode());
             }
 
-            Properties properties = new Properties();
-            cookieStore.getCookies().stream().collect(Collectors.toMap(Cookie::getName, Cookie::getValue))
-                    .forEach(properties::setProperty);
-            properties.store(new FileWriter(CookieHelper.getCookies().toFile()), "");
+            CookieHelper.storeCookies(cookieStore);
 
             return Jsoup.parse(
                     oktaAwsAppResponse.getEntity().getContent(),
@@ -114,15 +94,7 @@ public class OktaSaml {
     }
 
     private boolean reuseSession() throws JSONException, IOException {
-        CookieStore cookieStore = new BasicCookieStore();
-        Properties loadedProperties = new Properties();
-        loadedProperties.load(new FileReader(CookieHelper.getCookies().toFile()));
-        loadedProperties.entrySet().stream().map(entry -> {
-            BasicClientCookie basicClientCookie = new BasicClientCookie(entry.getKey().toString(), entry.getValue().toString());
-            basicClientCookie.setDomain(environment.oktaOrg);
-
-            return basicClientCookie;
-        }).forEach(cookieStore::addCookie);
+        CookieStore cookieStore = CookieHelper.loadCookies(environment);
 
         Optional<String> sidCookie = cookieStore.getCookies().stream().filter(cookie -> "sid".equals(cookie.getName())).findFirst().map(Cookie::getValue);
 
@@ -141,4 +113,5 @@ public class OktaSaml {
             return authnResponse.getStatusLine().getStatusCode() == HttpStatus.SC_OK;
         }
     }
+
 }

--- a/src/main/java/com/okta/tools/util/NodeListIterable.java
+++ b/src/main/java/com/okta/tools/util/NodeListIterable.java
@@ -1,0 +1,35 @@
+package com.okta.tools.util;
+
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.util.Iterator;
+
+public final class NodeListIterable implements Iterable<Node>
+{
+    private final NodeList nodeList;
+
+    public NodeListIterable(NodeList nodeList) {
+        this.nodeList = nodeList;
+    }
+
+    @Override
+    public Iterator<Node> iterator() {
+        return new NodeListIterator();
+    }
+
+    public final class NodeListIterator implements Iterator<Node>
+    {
+        private int index = 0;
+
+        @Override
+        public boolean hasNext() {
+            return index < nodeList.getLength();
+        }
+
+        @Override
+        public Node next() {
+            return nodeList.item(index++);
+        }
+    }
+}


### PR DESCRIPTION
Problem Statement
-----------------
App-based MFA and Okta's Duo Push integration don't work from a CLI-based interaction.

Solution
--------
Perform browser-based authentication using an embedded JavaFX WebView.
Capture SAMLResponse and sid for downstream use.

Testing
--------
Add `OKTA_BROWSER_AUTH=true` to **~/.okta/config.properties**
Run `env OKTA_PROFILE=dev awscli logout`
Run `env OKTA_PROFILE=dev awscli sts get-caller-identity`, expect browser auth experience to appear
Authenticate via JavaFX WebView
Expect prompt for role in CLI
Pick a role (any role, it doesn't matter)
Expect it to output information about the assumed role
Run `env OKTA_PROFILE=dev awscli sts get-caller-identity`, expect no auth
Expect it to output information about the assumed role
Run `env OKTA_PROFILE=dev2 awscli sts get-caller-identity`, expect prompt for role
Pick a role (any role, it doesn't matter)
Expect it to output information about the assumed role
Run `env OKTA_PROFILE=dev2 awscli sts get-caller-identity`, expect no auth
Expect it to output information about the assumed role