### PR TITLE
:seedling: Adds authentication support when using AWS java sdk

### DIFF
--- a/src/main/java/com/okta/tools/AWSCredentialsUtil.java
+++ b/src/main/java/com/okta/tools/AWSCredentialsUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Okta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.tools;
+
+import java.time.Instant;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.services.securitytoken.model.AssumeRoleWithSAMLResult;
+import com.amazonaws.services.securitytoken.model.Credentials;
+
+
+public class AWSCredentialsUtil {
+	
+	private AWSCredentialsUtil() {
+		// Utility class - should not be instantiated
+	}
+	
+	public static AWSCredentials getAWSCredential() throws Exception {
+		AssumeRoleWithSAMLResult samlResult = OktaAwsCliAssumeRole.withEnvironment(OktaAwsConfig.loadEnvironment()).getAssumeRoleWithSAMLResult(Instant.now());
+		
+		Credentials credentials = samlResult.getCredentials();
+		
+		return new BasicSessionCredentials(credentials.getAccessKeyId(), credentials.getSecretAccessKey(), credentials.getSessionToken());
+	}
+
+}

--- a/src/main/java/com/okta/tools/AWSCredentialsUtil.java
+++ b/src/main/java/com/okta/tools/AWSCredentialsUtil.java
@@ -22,19 +22,14 @@ import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.services.securitytoken.model.AssumeRoleWithSAMLResult;
 import com.amazonaws.services.securitytoken.model.Credentials;
 
+public interface AWSCredentialsUtil {
 
-public class AWSCredentialsUtil {
-	
-	private AWSCredentialsUtil() {
-		// Utility class - should not be instantiated
-	}
-	
-	public static AWSCredentials getAWSCredential() throws Exception {
-		AssumeRoleWithSAMLResult samlResult = OktaAwsCliAssumeRole.withEnvironment(OktaAwsConfig.loadEnvironment()).getAssumeRoleWithSAMLResult(Instant.now());
-		
-		Credentials credentials = samlResult.getCredentials();
-		
-		return new BasicSessionCredentials(credentials.getAccessKeyId(), credentials.getSecretAccessKey(), credentials.getSessionToken());
-	}
+    static AWSCredentials getAWSCredential() throws Exception {
+        AssumeRoleWithSAMLResult samlResult = OktaAwsCliAssumeRole.withEnvironment(OktaAwsConfig.loadEnvironment()).getAssumeRoleWithSAMLResult(Instant.now());
+
+        Credentials credentials = samlResult.getCredentials();
+
+        return new BasicSessionCredentials(credentials.getAccessKeyId(), credentials.getSecretAccessKey(), credentials.getSessionToken());
+    }
 
 }


### PR DESCRIPTION
Problem Statement
-----------------
Add authentication support when using AWS java sdk.

Solution
--------
When working with AWS java sdk it’s now possible to use

```
AWSCredentials credentials = AWSCredentialsUtil.getAWSCredential();
AWSStaticCredentialsProvider credentialsProvider = new AWSStaticCredentialsProvider(credentials);
```

to create the necessary credentials in order to make api calls.




