### PR TITLE
Check all pages to verify the samlresponse in browser auth

### DIFF
--- a/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
+++ b/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
@@ -65,7 +65,7 @@ public final class BrowserAuthentication extends Application {
 
         webEngine.getLoadWorker().stateProperty()
                 .addListener((ov, oldState, newState) -> {
-                    if (newState == State.SUCCEEDED) {
+                    if( webEngine.getDocument() != null ) {
                         checkForAwsSamlSignon(stage, webEngine, uri, headers);
                         stage.setTitle(webEngine.getLocation());
                     }


### PR DESCRIPTION
Problem Statement
-----------------
The in browser auth with MFA, not tested without, doesn't catch the samlresponse needed to close  it and proceed auth.
This because the page who has the form with the needed input with the samlresponse doesn't have the SUCCEED state in the redirects.

Solution
--------
Verify all page during redirects.

