### PR TITLE
Fix #138: Update Jsoup to 1.11.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <junit.jupiter.version>5.0.2</junit.jupiter.version>
         <junit.platform.version>1.0.1</junit.platform.version>
         <ini4j.version>0.5.4</ini4j.version>
-        <jsoup.version>1.11.2</jsoup.version>
+        <jsoup.version>1.11.3</jsoup.version>
         <opensaml.version>3.3.0</opensaml.version>
         <slf4j.version>1.7.25</slf4j.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,12 @@
         <!-- runtime dependencies -->
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
             <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Problem Statement
-----------------

On OSX, users sometimes get an empty role list while Linux users do not
esperience problems. This holds even true when the same Docker image is
used.

Solution
--------

We tracked this down to the document in `AwsSamlSigninParser` (the HTML document
that represents the HTML page AWS presents for selecting roles after login to
Okta) being broken judging by string representation of the `Document` object.
However, we noticed when converting the HTML response to a string before
passing it to `Jsoup.parse`, the error disappeared:

```java
    // in AwsSamlRoleUtils.getSigninPageDocument
    Scanner s = new Scanner(samlSigninResponse.getEntity().getContent()).useDelimiter("\\A");
    String result = s.hasNext() ? s.next() : "";
    System.out.println(result);
    return Jsoup.parse(
	    result,
	    "https://signin.aws.amazon.com/saml"
    );
```

This lead us to the conclusion that this might be a race condition that
only happens when Jsoup is passed an `InputStream` which could explain why it
only happens on OSX and not Linux: Such things can propagate down right to the
operating system through boundaries of VM/Docker.

Judging from Jsoup's changelog from 1.11.2 to 1.11.3, there is a
particular [change](https://github.com/jhy/jsoup/issues/995) that sounds
like this could be the solution. Anyways, when updating to the latest
version, the error disappears completely on our OSX machines.

This is a critical bug for our company and we would be glad if this would result into a new release as soon as possible. Thanks!