### PR TITLE
Pom: Do not include full AWS SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,12 @@
         <!-- runtime dependencies -->
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
             <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Problem Statement
-----------------

The jarfile is unneccessarily huge because the full AWS Java SDK is included.


Solution
--------

AWS conciously splitted the SDK in a myriad of Jarfiles, so one must only include the required ones.


