### PR TITLE
:bug: Fix #113

### DIFF
--- a/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
+++ b/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
@@ -20,16 +20,13 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
+import com.okta.tools.helpers.*;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.amazonaws.services.securitytoken.model.AssumeRoleWithSAMLRequest;
 import com.amazonaws.services.securitytoken.model.AssumeRoleWithSAMLResult;
-import com.okta.tools.helpers.ConfigHelper;
-import com.okta.tools.helpers.ProfileHelper;
-import com.okta.tools.helpers.RoleHelper;
-import com.okta.tools.helpers.SessionHelper;
 import com.okta.tools.models.Profile;
 import com.okta.tools.models.Session;
 import com.okta.tools.saml.OktaSaml;
@@ -59,12 +56,13 @@ final class OktaAwsCliAssumeRole {
     }
 
     private void init() throws Exception {
-        sessionHelper = new SessionHelper(environment);
+        CookieHelper cookieHelper = new CookieHelper(environment);
+        sessionHelper = new SessionHelper(environment, cookieHelper);
         configHelper = new ConfigHelper(environment);
         roleHelper = new RoleHelper(environment);
         profileHelper = new ProfileHelper(environment);
 
-        oktaSaml = new OktaSaml(environment);
+        oktaSaml = new OktaSaml(environment, cookieHelper);
 
         currentSession = sessionHelper.getCurrentSession();
 

--- a/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
+++ b/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
@@ -4,7 +4,6 @@ import com.okta.tools.OktaAwsCliEnvironment;
 import com.okta.tools.helpers.CookieHelper;
 import com.okta.tools.util.NodeListIterable;
 import javafx.application.Application;
-import javafx.concurrent.Worker.State;
 import javafx.scene.Group;
 import javafx.scene.Scene;
 import javafx.scene.control.ScrollPane;
@@ -35,12 +34,14 @@ public final class BrowserAuthentication extends Application {
     // Trade-off: JavaFX app model makes passing parameters to UI challenging
     // Experienced JavaFX devs welcomed to suggest solutions to this
     private static OktaAwsCliEnvironment ENVIRONMENT;
+    private static CookieHelper cookieHelper;
 
     // The value of samlResponse is only valid if USER_AUTH_COMPLETE has counted down to zero
     private static final AtomicReference<String> samlResponse = new AtomicReference<>();
 
     public static String login(OktaAwsCliEnvironment environment) throws InterruptedException {
         ENVIRONMENT = environment;
+        cookieHelper = new CookieHelper(ENVIRONMENT);
         launch();
         USER_AUTH_COMPLETE.await();
         return samlResponse.get();
@@ -142,7 +143,7 @@ public final class BrowserAuthentication extends Application {
         samlResponse.set(samlResponseForAws);
         try {
             CookieStore cookieStore = extractCookies(uri, headers);
-            CookieHelper.storeCookies(cookieStore);
+            cookieHelper.storeCookies(cookieStore);
         } catch (IOException e) {
             throw new RuntimeException(e);
         } finally {
@@ -153,6 +154,6 @@ public final class BrowserAuthentication extends Application {
 
     private CookieStore extractCookies(URI uri, Map<String, List<String>> headers) throws IOException {
         List<String> cookieHeaders = CookieHandler.getDefault().get(uri, headers).get("Cookie");
-        return CookieHelper.parseCookies(cookieHeaders);
+        return cookieHelper.parseCookies(cookieHeaders);
     }
 }

--- a/src/main/java/com/okta/tools/helpers/SessionHelper.java
+++ b/src/main/java/com/okta/tools/helpers/SessionHelper.java
@@ -18,10 +18,12 @@ public final class SessionHelper {
     private static final String OKTA_AWS_CLI_EXPIRY_PROPERTY = "OKTA_AWS_CLI_EXPIRY";
     private static final String OKTA_AWS_CLI_PROFILE_PROPERTY = "OKTA_AWS_CLI_PROFILE";
 
-    private OktaAwsCliEnvironment environment;
+    private final OktaAwsCliEnvironment environment;
+    private final CookieHelper cookieHelper;
 
-    public SessionHelper(OktaAwsCliEnvironment environment) {
+    public SessionHelper(OktaAwsCliEnvironment environment, CookieHelper cookieHelper) {
         this.environment = environment;
+        this.cookieHelper = cookieHelper;
     }
 
     /**
@@ -96,7 +98,7 @@ public final class SessionHelper {
     }
 
     private void logoutMultipleAccounts(String profileName) throws IOException {
-        CookieHelper.clearCookies();
+        cookieHelper.clearCookies();
 
         getMultipleProfile().deleteProfile(getMultipleProfilesPath().toString(), profileName);
     }


### PR DESCRIPTION
Problem Statement
-----------------
Attempts to reassign AWS token fail due to duplicate named HTTP cookies.

Solution
--------
 - Filter cookies to Okta org domain when calling Okta APIs

 - Refactor to include Okta environment in CookieHelper

