### PR TITLE
:bug: Fix #153 PowerShell crash with no proxy

### DIFF
--- a/bin/Install-OktaAwsCli.ps1
+++ b/bin/Install-OktaAwsCli.ps1
@@ -54,7 +54,9 @@ function With-Okta {
     try {
         $env:OKTA_PROFILE = $Profile
         $InternetOptions = Get-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings"
-        ($ProxyHost, $ProxyPort) = $InternetOptions.ProxyServer.Split(":")
+        if ($InternetOptions.ProxyServer) {
+            ($ProxyHost, $ProxyPort) = $InternetOptions.ProxyServer.Split(":")
+        }
         if ($InternetOptions.ProxyOverride) {
             $NonProxyHosts = [System.String]::Join("|", ($InternetOptions.ProxyOverride.Replace("<local>", "").Split(";") | Where-Object {$_}))
         } else {


### PR DESCRIPTION
Problem Statement
-----------------
PowerShell profile crashes with no Internet Options proxy set.


Solution
--------
Only do proxy selection if there is a proxy server.
