### PR TITLE
:bug: macOS install has broken JAR

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -34,7 +34,7 @@ This tool has been verified to work on macOS Sierra, High Sierra, Windows Server
 2. Open a PowerShell console (regular user, NOT admin it will break)
 3. Right-click once the paste the bootstrap script into the session
 4. Right-click a second time to paste and run the install script
-5. Customize **%userprofile%\.okta\config.properties** to reflect you Okta and Amazon Web Services setup
+5. Customize **%userprofile%\\.okta\\config.properties** to reflect your Okta and Amazon Web Services setup
 
 ### macOS/Linux
 
@@ -42,7 +42,7 @@ This tool has been verified to work on macOS Sierra, High Sierra, Windows Server
     ```bash
     curl 'https://raw.githubusercontent.com/oktadeveloper/okta-aws-cli-assume-role/master/bin/install.sh' | bash
     ```
-2. Customize **%userprofile%\.okta\config.properties** to reflect you Okta and Amazon Web Services setup
+2. Customize **~/.okta/config.properties** to reflect your Okta and Amazon Web Services setup
 
 ### Manual install
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -27,7 +27,7 @@ then
 fi
 
 mkdir -p ${HOME}/.okta
-curl 'https://github.com/oktadeveloper/okta-aws-cli-assume-role/releases/download/v1.0.2/okta-aws-cli-1.0.2.jar' --output "${HOME}/.okta/okta-aws-cli.jar"
+curl -L 'https://github.com/oktadeveloper/okta-aws-cli-assume-role/releases/download/v1.0.2/okta-aws-cli-1.0.2.jar' --output "${HOME}/.okta/okta-aws-cli.jar"
 
 # bash functions
 bash_functions="${HOME}/.okta/bash_functions"


### PR DESCRIPTION
Problem Statement
-----------------
macOS install leads to broken JAR containing redirect message:
https://github.com/oktadeveloper/okta-aws-cli-assume-role/issues/136#issuecomment-408755025

Solution
--------
 - Download JAR following redirects
 - Correct paths to config.properties in Readme