### PR TITLE
:art: Remove profile prefix

### DIFF
--- a/src/main/java/com/okta/tools/aws/settings/Configuration.java
+++ b/src/main/java/com/okta/tools/aws/settings/Configuration.java
@@ -25,7 +25,7 @@ public class Configuration extends Settings {
     static final String ROLE_ARN = "role_arn";
     static final String SOURCE_PROFILE = "source_profile";
     static final String REGION = "region";
-    static final String PROFILE_PREFIX = "profile ";
+    static final String PROFILE_PREFIX = "";
 
     /**
      * Create a Configuration object from a given {@link Reader}. The data given by this {@link Reader} should

--- a/src/test/java/com/okta/tools/aws/settings/ConfigurationTest.java
+++ b/src/test/java/com/okta/tools/aws/settings/ConfigurationTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class ConfigurationTest {
 
-    private String existingProfile = "[profile default]\n"
+    private String existingProfile = "[default]\n"
             + Configuration.ROLE_ARN + " = " + "arn:aws:iam:12345:role/foo" + "\n"
             + SOURCE_PROFILE + " = " + "default-source_profile" + "\n"
             + Configuration.REGION + " = " + "default-region";
@@ -42,7 +42,7 @@ class ConfigurationTest {
     private String profileName = "new-profilename";
     private String role_arn = "arn:aws:iam:67890:role/bar";
     private String region = "us-east-1";
-    private String manualRole = "[profile " + profileName + "]\n"
+    private String manualRole = "[" + profileName + "]\n"
             + Configuration.ROLE_ARN + " = " + role_arn + "\n"
             + SOURCE_PROFILE + " = " + profileName + "_source\n"
             + Configuration.REGION + " = " + region;
@@ -114,7 +114,7 @@ class ConfigurationTest {
         final Configuration configuration = new Configuration(configurationReader);
 
         final String updatedPrefix = "updated_";
-        final String expected = "[profile " + profileName + "]\n"
+        final String expected = "[" + profileName + "]\n"
                 + Configuration.ROLE_ARN + " = " + updatedPrefix + role_arn + "\n"
                 + SOURCE_PROFILE + " = " + profileName + "_source\n"
                 + Configuration.REGION + " = " + region


### PR DESCRIPTION
Problem Statement
-----------------

> We get the following warning for every profile in ~/.aws/config that uses this convention, in the next version can you stop putting the 'profile ' prefix in the config ini and just have the profile name.
> 
> `WARN [main] - 2018-07-30 16:38:06.131; - (BasicProfileConfigLoader.java:96) - The legacy profile format requires the 'profile ' prefix before the profile name. The latest code does not require such prefix, and will consider it as part of the profile name. Please remove the prefix if you are seeing this warning.`

#157 

Solution
--------

 - Remove profile prefix from profile names

 - Support configuring default profile via OKTA_PROFILE=default
