### PR TITLE
:seedling: Allow default profile

### DIFF
--- a/src/main/java/com/okta/tools/aws/settings/Configuration.java
+++ b/src/main/java/com/okta/tools/aws/settings/Configuration.java
@@ -50,7 +50,7 @@ public class Configuration extends Settings {
     public void addOrUpdateProfile(String name, String roleToAssume, String region) {
         // profileName is the string used for the section in the AWS config file.
         // This should be prefixed with "profile ".
-        final String profileName = PROFILE_PREFIX + name;
+        final String profileName = "default".equals(name) ? "default" : PROFILE_PREFIX + name;
 
         // Determine whether this is a new AWS configuration file. If it is, we'll set the default
         // profile to this profile.
@@ -68,7 +68,7 @@ public class Configuration extends Settings {
 
     private void writeConfigurationProfile(Profile.Section awsProfile, String name, String roleToAssume, String region) {
         awsProfile.put(ROLE_ARN, roleToAssume);
-        awsProfile.put(SOURCE_PROFILE, name + "_source");
+        awsProfile.put(SOURCE_PROFILE, "default".equals(name) ? "default" : name + "_source");
         if (!awsProfile.containsKey(REGION)) {
             awsProfile.put(REGION, region);
         }

--- a/src/main/java/com/okta/tools/aws/settings/Credentials.java
+++ b/src/main/java/com/okta/tools/aws/settings/Credentials.java
@@ -52,7 +52,7 @@ public class Credentials extends Settings {
      * @param awsSessionToken The session token to use for the profile.
      */
     public void addOrUpdateProfile(String name, String awsAccessKey, String awsSecretKey, String awsSessionToken) {
-        name = name + "_source";
+        name = "default".equals(name) ? "default" : name + "_source";
         final Profile.Section awsProfile = settings.get(name) != null ? settings.get(name) : settings.add(name);
         writeCredentialsProfile(awsProfile, awsAccessKey, awsSecretKey, awsSessionToken);
     }

--- a/src/test/java/com/okta/tools/aws/settings/CredentialsTest.java
+++ b/src/test/java/com/okta/tools/aws/settings/CredentialsTest.java
@@ -16,11 +16,13 @@
 package com.okta.tools.aws.settings;
 
 import org.junit.jupiter.api.Test;
-import org.junit.platform.commons.util.StringUtils;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CredentialsTest {
 
@@ -98,6 +100,31 @@ class CredentialsTest {
                 + Credentials.SESSION_TOKEN + " = " + updatedPrefix + sessionToken;
 
         credentials.addOrUpdateProfile(roleName, updatedPrefix + accessKey, updatedPrefix + secretKey, updatedPrefix + sessionToken);
+        credentials.save(credentialsWriter);
+
+        String given = org.apache.commons.lang.StringUtils.remove(credentialsWriter.toString().trim(), '\r');
+
+        assertEquals(expected, given);
+    }
+
+    /*
+     * Test updating default profile.
+     */
+    @Test
+    void addOrUpdateDefaultProfileToExistingProfile() throws IOException {
+        final StringReader credentialsReader = new StringReader(existingCredentials + "\n\n" + manualRole);
+        final StringWriter credentialsWriter = new StringWriter();
+        final Credentials credentials = new Credentials(credentialsReader);
+
+        final String updatedPrefix = "updated_";
+        final String expected =
+                "[default]\n"
+                + Credentials.ACCES_KEY_ID + " = " + updatedPrefix + accessKey + "\n"
+                + Credentials.SECRET_ACCESS_KEY + " = " + updatedPrefix + secretKey + "\n"
+                + Credentials.SESSION_TOKEN + " = " + updatedPrefix + sessionToken + "\n\n"
+                + manualRole;
+
+        credentials.addOrUpdateProfile("default", updatedPrefix + accessKey, updatedPrefix + secretKey, updatedPrefix + sessionToken);
         credentials.save(credentialsWriter);
 
         String given = org.apache.commons.lang.StringUtils.remove(credentialsWriter.toString().trim(), '\r');


### PR DESCRIPTION
Problem Statement
-----------------
This tool does not allow you to create a working default profile.

Solution
--------
 - Support default as a named profile via OKTA_PROFILE=default
