### PR TITLE
Use credentials suffix in AWS configuration

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -121,7 +121,7 @@ Here is the list of parameters that can be environment variables or settings in 
   - ```OKTA_AWS_REGION``` is the default AWS region to store with the created profile.
   - ```OKTA_AWS_ROLE_TO_ASSUME``` is the role to use. If present will try to match okta account's retrieved role list and use it. Will still prompt if no match found.
   - ```OKTA_STS_DURATION``` is the duration the role will be assumed, in seconds. The maximum session duration allowed by AWS is 12 hours and this needs to be set on the role as well.  Defaults to 1hr.
-  - ```OKTA_PROFLE_PREFIX``` is the text to prepend to the section name in ~/.aws/config for a named profile.  Defaults to "profile " (necessary for use with AWS CLI).
+  - ```OKTA_PROFILE_PREFIX``` is the text to prepend to the section name in ~/.aws/config for a named profile.  Defaults to "profile " (necessary for use with AWS CLI).
   - ```OKTA_CREDENTIALS_SUFFIX``` is the text to append to the section name in ~/.aws/credentals for a named profile.  Defaults to "_source" (necessary for use with AWS Tools for Windows PowerShell).
   
   - **Obtaining the AWS app url**

--- a/src/main/java/com/okta/tools/aws/settings/Configuration.java
+++ b/src/main/java/com/okta/tools/aws/settings/Configuration.java
@@ -74,7 +74,7 @@ public class Configuration extends Settings {
 
     private void writeConfigurationProfile(Profile.Section awsProfile, String name, String roleToAssume, String region) {
         awsProfile.put(ROLE_ARN, roleToAssume);
-        awsProfile.put(SOURCE_PROFILE, "default".equals(name) ? "default" : name + "_source");
+        awsProfile.put(SOURCE_PROFILE, "default".equals(name) ? "default" : name + environment.credentialsSuffix);
         if (!awsProfile.containsKey(REGION)) {
             awsProfile.put(REGION, region);
         }


### PR DESCRIPTION
Problem Statement
-----------------
The fix for #161 still unconditionally uses `_source` when writing the AWS configuration file.


Solution
--------
Use the environment setting `OKTA_CREDENTIALS_SUFFIX` (or its default value if not set) instead of `_source`.
