### PR TITLE
fix bash functions to work as documentation states 

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -35,14 +35,8 @@ grep '^#OktaAWSCLI' "${bash_functions}" > /dev/null 2>&1
 if [ $? -ne 0 ]
 then
 echo '
-function withokta {
-    java -Djava.net.useSystemProxies com.okta.tools.WithOkta $@
-}
 function aws {
-    withokta "aws --profile $1" $@
-}
-function sls {
-    withokta "sls --stage $1" $@
+    withokta aws $@
 }
 ' >> "${bash_functions}"
 fi


### PR DESCRIPTION
(only tested on Mac OSX 10.13.8, High Sierra)

Problem Statement
-----------------
```
Running the bash functions as-is gives this stack trace:
`` ~  aws okta sts get-caller-identity
Exception in thread "main" java.io.IOException: Cannot run program "aws --profile okta": error=2, No such file or directory
	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
	at com.okta.tools.WithOkta.main(WithOkta.java:25)
Caused by: java.io.IOException: error=2, No such file or directory
	at java.lang.UNIXProcess.forkAndExec(Native Method)
	at java.lang.UNIXProcess.<init>(UNIXProcess.java:247)
	at java.lang.ProcessImpl.start(ProcessImpl.java:134)
	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
	... 1 more
```


Solution
--------
Change to be much simpler, and pass the arguments to withokta correctly.

