### PR TITLE
Rework auth request code to provide useful error messages

### DIFF
--- a/src/main/java/com/okta/tools/authentication/OktaAuthentication.java
+++ b/src/main/java/com/okta/tools/authentication/OktaAuthentication.java
@@ -44,6 +44,7 @@ public final class OktaAuthentication {
         // "sessionProperty" = An ephemeral one-time token used to bootstrap an Okta session.
         final String sessionProperty = "sessionToken";
 
+        // Template used to build a missing property exception message.
         final String missingProperty = "Could not find the expected property \"%s\" in the response message.";
 
         // Sanity check: Does the (required) status property exist?
@@ -148,6 +149,7 @@ public final class OktaAuthentication {
         entity.setContentType("application/json");
         httpPost.setEntity(entity);
 
+        logger.debug("Calling okta authn service at " + httpPost.getURI());
         try (CloseableHttpClient httpClient = HttpClients.createSystem()) {
             CloseableHttpResponse authnResponse = httpClient.execute(httpPost);
 

--- a/src/main/java/com/okta/tools/authentication/TransactionState.java
+++ b/src/main/java/com/okta/tools/authentication/TransactionState.java
@@ -1,0 +1,53 @@
+package com.okta.tools.authentication;
+
+/**
+ * Okta transaction state codes. See:
+ *   https://developer.okta.com/docs/api/resources/authn#transaction-state
+ */
+public enum TransactionState {
+  // So that default value is invalid
+  INVALID("NOT A VALID TRANSACTIONSTATE"),
+
+  UNAUTHENTICATED("Early Access User tried to access protected resource (ex: an app) but user is not " +
+      "authenticated POST to the next link relation to authenticate user credentials."),
+
+  PASSWORD_WARN("The user’s password was successfully validated but is about to expire and should be changed. POST " +
+      "to the next link relation to change the user’s password."),
+
+  PASSWORD_EXPIRED("The user’s password was successfully validated but is expired. POST to the next link relation to" +
+      " change the user’s expired password."),
+
+  RECOVERY("The user has requested a recovery token to reset their password or unlock their account. POST to the " +
+      "next link relation to answer the user’s recovery question."),
+
+  RECOVERY_CHALLENGE("The user must verify the factor-specific recovery challenge. " +
+      "POST to the verify link relation to verify the recovery factor."),
+
+  PASSWORD_RESET("The user successfully answered their recovery question and must to set a new password. POST to the" +
+      " next link relation to reset the user’s password."),
+
+  LOCKED_OUT("The user account is locked; self-service unlock or administrator unlock is required. POST to the " +
+      "unlock link relation to perform a self-service unlock."),
+
+  MFA_ENROLL("The user must select and enroll an available factor for additional verification. POST to the enroll " +
+      "link relation for a specific factor to enroll the factor."),
+
+  MFA_ENROLL_ACTIVATE("The user must activate the factor to complete enrollment. POST to the next link relation to " +
+      "activate the factor."),
+
+  MFA_REQUIRED("The user must provide additional verification with a previously enrolled factor. POST to the verify " +
+      "link relation for a specific factor to provide additional verification."),
+
+  MFA_CHALLENGE("The user must verify the factor-specific challenge. POST to the verify link relation to verify the " +
+      "factor."),
+
+  SUCCESS("Transaction completed successfully.");
+
+  private final String description;
+
+  TransactionState(String description) {
+    this.description = description;
+  }
+
+  public String getDescription() { return this.description; }
+}


### PR DESCRIPTION
Problem Statement
-----------------
Was getting json responses from the authn call that were of 'status' : 'MFA_ENROLL' , and had no 'sessionToken', but did have a `stateToken`. The app crashed with a JSON parse error with very little useful information. 

```
→ okta sts get-caller-identity
Username: XXXXXXX
Password:
Exception in thread "main" org.json.JSONException: JSONObject["sessionToken"] not found.
    at org.json.JSONObject.get(JSONObject.java:520)
    at org.json.JSONObject.getString(JSONObject.java:806)
    at com.okta.tools.authentication.OktaAuthentication.getOktaSessionToken(OktaAuthentication.java:40)
    at com.okta.tools.saml.OktaSaml.getSamlResponse(OktaSaml.java:46)
    at com.okta.tools.OktaAwsCliAssumeRole.doRequest(OktaAwsCliAssumeRole.java:106)
    at com.okta.tools.OktaAwsCliAssumeRole.run(OktaAwsCliAssumeRole.java:90)
    at com.okta.tools.awscli.main(awscli.java:40)
```

PROBLEM: Valid responses from the authn endpoint should not crash outright but rather provide the user with information to help diagnose the problem. 

Solution
--------
This PR restructures the authn response handling code to be more defensive in nature. It parses the incoming response json based on the status code, which looks sane based on the docks on okta. It adds a number of sanity checks and, if something goes awry the user will get a helpful error message and a copy of the response json in their command line output. The enum+switch structure makes it easy to expand coverage of the various various features of the okta API. Also added some doc strings and pointers to the Okta documentation where relevant.

In the same missing "sessionToken" scenario, our user will see this much more helpful message:
```bash
> okta sts get-caller-identity
Username: myuser
Password:
Exception in thread "main" java.lang.IllegalStateException: Could not find the expected property "sessionToken" in the response message.

Message:
{
   "_embedded":{
      "user":{
         "profile":{
            "firstName":"dhjfkc",
            "lastName":"fdsf",
            "timeZone":"America/Los_Angeles",
            "login":"myuser@myco.com",
            "locale":"en"
         },
         "id":"00ulble6ayd6xOn48g0x7"
      },
      "factors":[
         {
            "provider":"OKTA",
            "_links":{
               "enroll":{
                  "hints":{
                     "allow":[
                        "POST"
                     ]
                  },
                  "href":"https://myco.okta.com/api/v1/authn/factors"
               }
            },
            "factorType":"push",
            "vendorName":"OKTA",
            "status":"NOT_SETUP",
            "enrollment":"REQUIRED"
         }
      ]
   },
   "_links":{
      "cancel":{
         "hints":{
            "allow":[
               "POST"
            ]
         },
         "href":"https://myco.okta.com/api/v1/authn/cancel"
      }
   },
   "stateToken":"00rAYJMd49Da10B0H4aJmGoCzrFj4AZ4lQS5W3f1bd",
   "expiresAt":"2018-08-08T23:50:34.000Z",
   "status":"MFA_ENROLL"
}

	at com.okta.tools.authentication.OktaAuthentication.makeException(OktaAuthentication.java:222)
	at com.okta.tools.authentication.OktaAuthentication.makeException(OktaAuthentication.java:209)
	at com.okta.tools.authentication.OktaAuthentication.getOktaSessionToken(OktaAuthentication.java:80)
	at com.okta.tools.saml.OktaSaml.getSamlResponse(OktaSaml.java:46)
	at com.okta.tools.OktaAwsCliAssumeRole.doRequest(OktaAwsCliAssumeRole.java:106)
	at com.okta.tools.OktaAwsCliAssumeRole.run(OktaAwsCliAssumeRole.java:90)
	at com.okta.tools.awscli.main(awscli.java:40)```