### PR TITLE
:bug: Closing browser auth doesn't quit

### DIFF
--- a/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
+++ b/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
@@ -51,8 +51,8 @@ public final class BrowserAuthentication extends Application {
     public void start(final Stage stage) throws IOException {
         stage.setWidth(802);
         stage.setHeight(650);
+        stage.setOnCloseRequest(event -> System.exit(1));
         Scene scene = new Scene(new Group());
-
 
         final WebView browser = new WebView();
         final WebEngine webEngine = browser.getEngine();


### PR DESCRIPTION
Problem Statement
-----------------
> Manually closing the browser auth window with the embedded browser doesn't quit the program. It stays running in a stuck/broken state.

Solution
--------
 - Clicking close exits the application with code 1

Resolves #163