### PR TITLE
:art: Clearer app sign on rule failure messages

### DIFF
--- a/src/main/java/com/okta/tools/saml/OktaSaml.java
+++ b/src/main/java/com/okta/tools/saml/OktaSaml.java
@@ -68,20 +68,24 @@ public class OktaSaml {
             } else {
                 Elements errorContent = document.getElementsByClass("error-content");
                 Elements errorHeadline = errorContent.select("h1");
-                if (errorHeadline.isEmpty()) {
-                    throw new RuntimeException("You do not have access to AWS through Okta. \nPlease contact your administrator.");
-                } else {
+                if (errorHeadline.hasText()) {
                     throw new RuntimeException(errorHeadline.text());
+                } else {
+                    throw new RuntimeException("You do not have access to AWS through Okta. \nPlease contact your administrator.");
                 }
             }
         }
         return samlResponseInputElement.attr("value");
     }
 
+    // Heuristic based on undocumented behavior observed experimentally
+    // This condition may be missed Okta significantly changes the app-level re-auth page
     private boolean isPasswordAuthenticationChallenge(Document document) {
         return document.getElementById("password-verification-challenge") != null;
     }
 
+    // Heuristic based on undocumented behavior observed experimentally
+    // This condition may be missed if Okta significantly changes the app-level MFA page
     private boolean isPromptForFactorChallenge(Document document) {
         return document.getElementById("okta-sign-in") != null;
     }

--- a/src/main/java/com/okta/tools/saml/OktaSaml.java
+++ b/src/main/java/com/okta/tools/saml/OktaSaml.java
@@ -79,7 +79,7 @@ public class OktaSaml {
     }
 
     // Heuristic based on undocumented behavior observed experimentally
-    // This condition may be missed Okta significantly changes the app-level re-auth page
+    // This condition may be missed if Okta significantly changes the app-level re-auth page
     private boolean isPasswordAuthenticationChallenge(Document document) {
         return document.getElementById("password-verification-challenge") != null;
     }


### PR DESCRIPTION
Problem Statement
-----------------
When app sign on policies are unsupported the tool responds like this:
```plain
You do not have access to AWS through Okta.
Please contact your administrator.
```
That is inaccurate and confusing and leads to issue reports that would be better handled as feature requests with use cases outlined.

Solution
--------

 - Differentiate sign-on failure due to app-level MFA

 - Differentiate sign-on failure due to app-level re-auth challenge

 - Use failure message from Okta when available otherwise
