### PR TITLE
:bug: Correctly handle nested configs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
             <version>${json.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+            <version>2.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>${log4j.version}</version>
@@ -84,11 +89,6 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>${log4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.ini4j</groupId>
-            <artifactId>ini4j</artifactId>
-            <version>${ini4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
@@ -137,6 +137,13 @@
             <artifactId>apiguardian-api</artifactId>
             <version>1.0.0</version>
             <scope>test</scope>
+        </dependency>
+        <!-- Dynamic dependency of commons-configuration -->
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.9.3</version>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/okta/tools/aws/settings/AwsINIConfiguration.java
+++ b/src/main/java/com/okta/tools/aws/settings/AwsINIConfiguration.java
@@ -1,0 +1,875 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.tools.aws.settings;
+
+import org.apache.commons.configuration2.*;
+import org.apache.commons.configuration2.convert.ListDelimiterHandler;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationRuntimeException;
+import org.apache.commons.configuration2.tree.*;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.*;
+import java.util.*;
+
+/**
+ * <p>Customized copy of INIConfiguration tuned for use with AWS INI-like files.</p>
+ * <p>Changes to support indented properties:
+ *     <ul>
+ *         <li>Right trim lines (original trims left and right)</li>
+ *         <li>Right trim keys (original trims left and right)</li>
+ *     </ul>
+ * </p>
+ */
+public class AwsINIConfiguration extends BaseHierarchicalConfiguration implements
+        FileBasedConfiguration
+{
+    /**
+     * The characters that signal the start of a comment line.
+     */
+    protected static final String COMMENT_CHARS = "#;";
+
+    /**
+     * The characters used to separate keys from values.
+     */
+    protected static final String SEPARATOR_CHARS = "=:";
+
+    /**
+     * Constant for the line separator.
+     */
+    private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+
+    /**
+     * The characters used for quoting values.
+     */
+    private static final String QUOTE_CHARACTERS = "\"'";
+
+    /**
+     * The line continuation character.
+     */
+    private static final String LINE_CONT = "\\";
+
+    /**
+     * The separator used when writing an INI file.
+     */
+    private String separatorUsedInOutput = " = ";
+
+    /**
+     * Create a new empty INI Configuration.
+     */
+    public AwsINIConfiguration()
+    {
+        super();
+    }
+
+    /**
+     * Creates a new instance of {@code INIConfiguration} with the
+     * content of the specified {@code HierarchicalConfiguration}.
+     *
+     * @param c the configuration to be copied
+     * @since 2.0
+     */
+    public AwsINIConfiguration(HierarchicalConfiguration<ImmutableNode> c)
+    {
+        super(c);
+    }
+
+    /**
+     * Get separator used in INI output. see {@code setSeparatorUsedInOutput}
+     * for further explanation
+     *
+     * @return the current separator for writing the INI output
+     * @since 2.2
+     */
+    public String getSeparatorUsedInOutput()
+    {
+        beginRead(false);
+        try
+        {
+            return separatorUsedInOutput;
+        }
+        finally
+        {
+            endRead();
+        }
+    }
+
+    /**
+     * Allows setting the key and value separator which is used for the creation
+     * of the resulting INI output
+     *
+     * @param separator String of the new separator for INI output
+     * @since 2.2
+     */
+    public void setSeparatorUsedInOutput(String separator)
+    {
+        beginWrite(false);
+        try
+        {
+            this.separatorUsedInOutput = separator;
+        }
+        finally
+        {
+            endWrite();
+        }
+    }
+
+    /**
+     * Save the configuration to the specified writer.
+     *
+     * @param writer - The writer to save the configuration to.
+     * @throws ConfigurationException If an error occurs while writing the
+     *         configuration
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void write(Writer writer) throws ConfigurationException, IOException
+    {
+        PrintWriter out = new PrintWriter(writer);
+        boolean first = true;
+        final String separator = getSeparatorUsedInOutput();
+
+        beginRead(false);
+        try
+        {
+            for (ImmutableNode node : getModel().getNodeHandler().getRootNode()
+                    .getChildren())
+            {
+                if (isSectionNode(node))
+                {
+                    if (!first)
+                    {
+                        out.println();
+                    }
+                    out.print("[");
+                    out.print(node.getNodeName());
+                    out.print("]");
+                    out.println();
+
+                    for (ImmutableNode child : node.getChildren())
+                    {
+                        writeProperty(out, child.getNodeName(),
+                                child.getValue(), separator);
+                    }
+                }
+                else
+                {
+                    writeProperty(out, node.getNodeName(), node.getValue(), separator);
+                }
+                first = false;
+            }
+            out.println();
+            out.flush();
+        }
+        finally
+        {
+            endRead();
+        }
+    }
+
+    /**
+     * Load the configuration from the given reader. Note that the
+     * {@code clear()} method is not called so the configuration read in will
+     * be merged with the current configuration.
+     *
+     * @param in the reader to read the configuration from.
+     * @throws ConfigurationException If an error occurs while reading the
+     *         configuration
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void read(Reader in) throws ConfigurationException, IOException
+    {
+        BufferedReader bufferedReader = new BufferedReader(in);
+        Map<String, ImmutableNode.Builder> sectionBuilders = new LinkedHashMap<>();
+        ImmutableNode.Builder rootBuilder = new ImmutableNode.Builder();
+
+        createNodeBuilders(bufferedReader, rootBuilder, sectionBuilders);
+        ImmutableNode rootNode = createNewRootNode(rootBuilder, sectionBuilders);
+        addNodes(null, rootNode.getChildren());
+    }
+
+    /**
+     * Creates a new root node from the builders constructed while reading the
+     * configuration file.
+     *
+     * @param rootBuilder the builder for the top-level section
+     * @param sectionBuilders a map storing the section builders
+     * @return the root node of the newly created hierarchy
+     */
+    private static ImmutableNode createNewRootNode(
+            ImmutableNode.Builder rootBuilder,
+            Map<String, ImmutableNode.Builder> sectionBuilders)
+    {
+        for (Map.Entry<String, ImmutableNode.Builder> e : sectionBuilders
+                .entrySet())
+        {
+            rootBuilder.addChild(e.getValue().name(e.getKey()).create());
+        }
+        return rootBuilder.create();
+    }
+
+    /**
+     * Reads the content of an INI file from the passed in reader and creates a
+     * structure of builders for constructing the {@code ImmutableNode} objects
+     * representing the data.
+     *
+     * @param in the reader
+     * @param rootBuilder the builder for the top-level section
+     * @param sectionBuilders a map storing the section builders
+     * @throws IOException if an I/O error occurs
+     */
+    private void createNodeBuilders(BufferedReader in,
+                                    ImmutableNode.Builder rootBuilder,
+                                    Map<String, ImmutableNode.Builder> sectionBuilders)
+            throws IOException
+    {
+        ImmutableNode.Builder sectionBuilder = rootBuilder;
+        String line = in.readLine();
+        while (line != null)
+        {
+            line = StringUtils.stripEnd(line, null);
+            if (!isCommentLine(line))
+            {
+                if (isSectionLine(line))
+                {
+                    String section = line.substring(1, line.length() - 1);
+                    sectionBuilder = sectionBuilders.get(section);
+                    if (sectionBuilder == null)
+                    {
+                        sectionBuilder = new ImmutableNode.Builder();
+                        sectionBuilders.put(section, sectionBuilder);
+                    }
+                }
+
+                else
+                {
+                    String key;
+                    String value = "";
+                    int index = findSeparator(line);
+                    if (index >= 0)
+                    {
+                        key = line.substring(0, index);
+                        value = parseValue(line.substring(index + 1), in);
+                    }
+                    else
+                    {
+                        key = line;
+                    }
+                    key = StringUtils.stripEnd(key, null);
+                    if (key.length() < 1)
+                    {
+                        // use space for properties with no key
+                        key = " ";
+                    }
+                    createValueNodes(sectionBuilder, key, value);
+                }
+            }
+
+            line = in.readLine();
+        }
+    }
+
+    /**
+     * Creates the node(s) for the given key value-pair. If delimiter parsing is
+     * enabled, the value string is split if possible, and for each single value
+     * a node is created. Otherwise only a single node is added to the section.
+     *
+     * @param sectionBuilder the section builder for adding new nodes
+     * @param key the key
+     * @param value the value string
+     */
+    private void createValueNodes(ImmutableNode.Builder sectionBuilder,
+                                  String key, String value)
+    {
+        Collection<String> values =
+                getListDelimiterHandler().split(value, false);
+
+        for (String v : values)
+        {
+            sectionBuilder.addChild(new ImmutableNode.Builder().name(key)
+                    .value(v).create());
+        }
+    }
+
+    /**
+     * Writes data about a property into the given stream.
+     *
+     * @param out the output stream
+     * @param key the key
+     * @param value the value
+     */
+    private void writeProperty(PrintWriter out, String key, Object value, String separator)
+    {
+        out.print(key);
+        out.print(separator);
+        out.print(escapeValue(value.toString()));
+        out.println();
+    }
+
+    /**
+     * Parse the value to remove the quotes and ignoring the comment. Example:
+     *
+     * <pre>
+     * &quot;value&quot; ; comment -&gt; value
+     * </pre>
+     *
+     * <pre>
+     * 'value' ; comment -&gt; value
+     * </pre>
+     * Note that a comment character is only recognized if there is at least one
+     * whitespace character before it. So it can appear in the property value,
+     * e.g.:
+     * <pre>
+     * C:\\Windows;C:\\Windows\\system32
+     * </pre>
+     *
+     * @param val the value to be parsed
+     * @param reader the reader (needed if multiple lines have to be read)
+     * @throws IOException if an IO error occurs
+     */
+    private static String parseValue(String val, BufferedReader reader) throws IOException
+    {
+        StringBuilder propertyValue = new StringBuilder();
+        boolean lineContinues;
+        String value = val.trim();
+
+        do
+        {
+            boolean quoted = value.startsWith("\"") || value.startsWith("'");
+            boolean stop = false;
+            boolean escape = false;
+
+            char quote = quoted ? value.charAt(0) : 0;
+
+            int i = quoted ? 1 : 0;
+
+            StringBuilder result = new StringBuilder();
+            char lastChar = 0;
+            while (i < value.length() && !stop)
+            {
+                char c = value.charAt(i);
+
+                if (quoted)
+                {
+                    if ('\\' == c && !escape)
+                    {
+                        escape = true;
+                    }
+                    else if (!escape && quote == c)
+                    {
+                        stop = true;
+                    }
+                    else if (escape && quote == c)
+                    {
+                        escape = false;
+                        result.append(c);
+                    }
+                    else
+                    {
+                        if (escape)
+                        {
+                            escape = false;
+                            result.append('\\');
+                        }
+
+                        result.append(c);
+                    }
+                }
+                else
+                {
+                    if (isCommentChar(c) && Character.isWhitespace(lastChar))
+                    {
+                        stop = true;
+                    }
+                    else
+                    {
+                        result.append(c);
+                    }
+                }
+
+                i++;
+                lastChar = c;
+            }
+
+            String v = result.toString();
+            if (!quoted)
+            {
+                v = v.trim();
+                lineContinues = lineContinues(v);
+                if (lineContinues)
+                {
+                    // remove trailing "\"
+                    v = v.substring(0, v.length() - 1).trim();
+                }
+            }
+            else
+            {
+                lineContinues = lineContinues(value, i);
+            }
+            propertyValue.append(v);
+
+            if (lineContinues)
+            {
+                propertyValue.append(LINE_SEPARATOR);
+                value = reader.readLine();
+            }
+        } while (lineContinues && value != null);
+
+        return propertyValue.toString();
+    }
+
+    /**
+     * Tests whether the specified string contains a line continuation marker.
+     *
+     * @param line the string to check
+     * @return a flag whether this line continues
+     */
+    private static boolean lineContinues(String line)
+    {
+        String s = line.trim();
+        return s.equals(LINE_CONT)
+                || (s.length() > 2 && s.endsWith(LINE_CONT) && Character
+                .isWhitespace(s.charAt(s.length() - 2)));
+    }
+
+    /**
+     * Tests whether the specified string contains a line continuation marker
+     * after the specified position. This method parses the string to remove a
+     * comment that might be present. Then it checks whether a line continuation
+     * marker can be found at the end.
+     *
+     * @param line the line to check
+     * @param pos the start position
+     * @return a flag whether this line continues
+     */
+    private static boolean lineContinues(String line, int pos)
+    {
+        String s;
+
+        if (pos >= line.length())
+        {
+            s = line;
+        }
+        else
+        {
+            int end = pos;
+            while (end < line.length() && !isCommentChar(line.charAt(end)))
+            {
+                end++;
+            }
+            s = line.substring(pos, end);
+        }
+
+        return lineContinues(s);
+    }
+
+    /**
+     * Tests whether the specified character is a comment character.
+     *
+     * @param c the character
+     * @return a flag whether this character starts a comment
+     */
+    private static boolean isCommentChar(char c)
+    {
+        return COMMENT_CHARS.indexOf(c) >= 0;
+    }
+
+    /**
+     * Tries to find the index of the separator character in the given string.
+     * This method checks for the presence of separator characters in the given
+     * string. If multiple characters are found, the first one is assumed to be
+     * the correct separator. If there are quoting characters, they are taken
+     * into account, too.
+     *
+     * @param line the line to be checked
+     * @return the index of the separator character or -1 if none is found
+     */
+    private static int findSeparator(String line)
+    {
+        int index =
+                findSeparatorBeforeQuote(line,
+                        findFirstOccurrence(line, QUOTE_CHARACTERS));
+        if (index < 0)
+        {
+            index = findFirstOccurrence(line, SEPARATOR_CHARS);
+        }
+        return index;
+    }
+
+    /**
+     * Checks for the occurrence of the specified separators in the given line.
+     * The index of the first separator is returned.
+     *
+     * @param line the line to be investigated
+     * @param separators a string with the separator characters to look for
+     * @return the lowest index of a separator character or -1 if no separator
+     *         is found
+     */
+    private static int findFirstOccurrence(String line, String separators)
+    {
+        int index = -1;
+
+        for (int i = 0; i < separators.length(); i++)
+        {
+            char sep = separators.charAt(i);
+            int pos = line.indexOf(sep);
+            if (pos >= 0)
+            {
+                if (index < 0 || pos < index)
+                {
+                    index = pos;
+                }
+            }
+        }
+
+        return index;
+    }
+
+    /**
+     * Searches for a separator character directly before a quoting character.
+     * If the first non-whitespace character before a quote character is a
+     * separator, it is considered the "real" separator in this line - even if
+     * there are other separators before.
+     *
+     * @param line the line to be investigated
+     * @param quoteIndex the index of the quote character
+     * @return the index of the separator before the quote or &lt; 0 if there is
+     *         none
+     */
+    private static int findSeparatorBeforeQuote(String line, int quoteIndex)
+    {
+        int index = quoteIndex - 1;
+        while (index >= 0 && Character.isWhitespace(line.charAt(index)))
+        {
+            index--;
+        }
+
+        if (index >= 0 && SEPARATOR_CHARS.indexOf(line.charAt(index)) < 0)
+        {
+            index = -1;
+        }
+
+        return index;
+    }
+
+    /**
+     * Escapes the given property value before it is written. This method add
+     * quotes around the specified value if it contains a comment character and
+     * handles list delimiter characters.
+     *
+     * @param value the string to be escaped
+     */
+    private String escapeValue(String value)
+    {
+        return String.valueOf(getListDelimiterHandler().escape(
+                escapeComments(value), ListDelimiterHandler.NOOP_TRANSFORMER));
+    }
+
+    /**
+     * Escapes comment characters in the given value.
+     *
+     * @param value the value to be escaped
+     * @return the value with comment characters escaped
+     */
+    private static String escapeComments(String value)
+    {
+        boolean quoted = false;
+
+        for (int i = 0; i < COMMENT_CHARS.length() && !quoted; i++)
+        {
+            char c = COMMENT_CHARS.charAt(i);
+            if (value.indexOf(c) != -1)
+            {
+                quoted = true;
+            }
+        }
+
+        if (quoted)
+        {
+            return '"' + value.replaceAll("\"", "\\\\\\\"") + '"';
+        }
+        else
+        {
+            return value;
+        }
+    }
+
+    /**
+     * Determine if the given line is a comment line.
+     *
+     * @param line The line to check.
+     * @return true if the line is empty or starts with one of the comment
+     *         characters
+     */
+    protected boolean isCommentLine(String line)
+    {
+        if (line == null)
+        {
+            return false;
+        }
+        // blank lines are also treated as comment lines
+        return line.length() < 1 || COMMENT_CHARS.indexOf(line.charAt(0)) >= 0;
+    }
+
+    /**
+     * Determine if the given line is a section.
+     *
+     * @param line The line to check.
+     * @return true if the line contains a section
+     */
+    protected boolean isSectionLine(String line)
+    {
+        if (line == null)
+        {
+            return false;
+        }
+        return line.startsWith("[") && line.endsWith("]");
+    }
+
+    /**
+     * Return a set containing the sections in this ini configuration. Note that
+     * changes to this set do not affect the configuration.
+     *
+     * @return a set containing the sections.
+     */
+    public Set<String> getSections()
+    {
+        Set<String> sections = new LinkedHashSet<>();
+        boolean globalSection = false;
+        boolean inSection = false;
+
+        beginRead(false);
+        try
+        {
+            for (ImmutableNode node : getModel().getNodeHandler().getRootNode()
+                    .getChildren())
+            {
+                if (isSectionNode(node))
+                {
+                    inSection = true;
+                    sections.add(node.getNodeName());
+                }
+                else
+                {
+                    if (!inSection && !globalSection)
+                    {
+                        globalSection = true;
+                        sections.add(null);
+                    }
+                }
+            }
+        }
+        finally
+        {
+            endRead();
+        }
+
+        return sections;
+    }
+
+    /**
+     * Returns a configuration with the content of the specified section. This
+     * provides an easy way of working with a single section only. The way this
+     * configuration is structured internally, this method is very similar to
+     * calling {@link HierarchicalConfiguration#configurationAt(String)} with
+     * the name of the section in question. There are the following differences
+     * however:
+     * <ul>
+     * <li>This method never throws an exception. If the section does not exist,
+     * it is created now. The configuration returned in this case is empty.</li>
+     * <li>If section is contained multiple times in the configuration, the
+     * configuration returned by this method is initialized with the first
+     * occurrence of the section. (This can only happen if
+     * {@code addProperty()} has been used in a way that does not conform
+     * to the storage scheme used by {@code INIConfiguration}.
+     * If used correctly, there will not be duplicate sections.)</li>
+     * <li>There is special support for the global section: Passing in
+     * <b>null</b> as section name returns a configuration with the content of
+     * the global section (which may also be empty).</li>
+     * </ul>
+     *
+     * @param name the name of the section in question; <b>null</b> represents
+     *        the global section
+     * @return a configuration containing only the properties of the specified
+     *         section
+     */
+    public SubnodeConfiguration getSection(String name)
+    {
+        if (name == null)
+        {
+            return getGlobalSection();
+        }
+
+        else
+        {
+            try
+            {
+                return (SubnodeConfiguration) configurationAt(name, true);
+            }
+            catch (ConfigurationRuntimeException iex)
+            {
+                // the passed in key does not map to exactly one node
+                // obtain the node for the section, create it on demand
+                InMemoryNodeModel parentModel = getSubConfigurationParentModel();
+                NodeSelector selector = parentModel.trackChildNodeWithCreation(null, name, this);
+                return createSubConfigurationForTrackedNode(selector, this);
+            }
+        }
+    }
+
+    /**
+     * Creates a sub configuration for the global section of the represented INI
+     * configuration.
+     *
+     * @return the sub configuration for the global section
+     */
+    private SubnodeConfiguration getGlobalSection()
+    {
+        InMemoryNodeModel parentModel = getSubConfigurationParentModel();
+        NodeSelector selector = new NodeSelector(null); // selects parent
+        parentModel.trackNode(selector, this);
+        AwsINIConfiguration.GlobalSectionNodeModel model =
+                new AwsINIConfiguration.GlobalSectionNodeModel(this, selector);
+        SubnodeConfiguration sub = new SubnodeConfiguration(this, model);
+        initSubConfigurationForThisParent(sub);
+        return sub;
+    }
+
+    /**
+     * Checks whether the specified configuration node represents a section.
+     *
+     * @param node the node in question
+     * @return a flag whether this node represents a section
+     */
+    private static boolean isSectionNode(ImmutableNode node)
+    {
+        return node.getValue() == null;
+    }
+
+    /**
+     * A specialized node model implementation for the sub configuration
+     * representing the global section of the INI file. This is a regular
+     * {@code TrackedNodeModel} with one exception: The {@code NodeHandler} used
+     * by this model applies a filter on the children of the root node so that
+     * only nodes are visible that are no sub sections.
+     */
+    private static class GlobalSectionNodeModel extends TrackedNodeModel
+    {
+        /**
+         * Creates a new instance of {@code GlobalSectionNodeModel} and
+         * initializes it with the given underlying model.
+         *
+         * @param modelSupport the underlying {@code InMemoryNodeModel}
+         * @param selector the {@code NodeSelector}
+         */
+        public GlobalSectionNodeModel(InMemoryNodeModelSupport modelSupport,
+                                      NodeSelector selector)
+        {
+            super(modelSupport, selector, true);
+        }
+
+        @Override
+        public NodeHandler<ImmutableNode> getNodeHandler()
+        {
+            return new NodeHandlerDecorator<ImmutableNode>()
+            {
+                @Override
+                public List<ImmutableNode> getChildren(ImmutableNode node)
+                {
+                    List<ImmutableNode> children = super.getChildren(node);
+                    return filterChildrenOfGlobalSection(node, children);
+                }
+
+                @Override
+                public List<ImmutableNode> getChildren(ImmutableNode node,
+                                                       String name)
+                {
+                    List<ImmutableNode> children =
+                            super.getChildren(node, name);
+                    return filterChildrenOfGlobalSection(node, children);
+                }
+
+                @Override
+                public int getChildrenCount(ImmutableNode node, String name)
+                {
+                    List<ImmutableNode> children =
+                            (name != null) ? super.getChildren(node, name)
+                                    : super.getChildren(node);
+                    return filterChildrenOfGlobalSection(node, children).size();
+                }
+
+                @Override
+                public ImmutableNode getChild(ImmutableNode node, int index)
+                {
+                    List<ImmutableNode> children = super.getChildren(node);
+                    return filterChildrenOfGlobalSection(node, children).get(
+                            index);
+                }
+
+                @Override
+                public int indexOfChild(ImmutableNode parent,
+                                        ImmutableNode child)
+                {
+                    List<ImmutableNode> children = super.getChildren(parent);
+                    return filterChildrenOfGlobalSection(parent, children)
+                            .indexOf(child);
+                }
+
+                @Override
+                protected NodeHandler<ImmutableNode> getDecoratedNodeHandler()
+                {
+                    return AwsINIConfiguration.GlobalSectionNodeModel.super.getNodeHandler();
+                }
+
+                /**
+                 * Filters the child nodes of the global section. This method
+                 * checks whether the passed in node is the root node of the
+                 * configuration. If so, from the list of children all nodes are
+                 * filtered which are section nodes.
+                 *
+                 * @param node the node in question
+                 * @param children the children of this node
+                 * @return a list with the filtered children
+                 */
+                private List<ImmutableNode> filterChildrenOfGlobalSection(
+                        ImmutableNode node, List<ImmutableNode> children)
+                {
+                    List<ImmutableNode> filteredList;
+                    if (node == getRootNode())
+                    {
+                        filteredList =
+                                new ArrayList<>(children.size());
+                        for (ImmutableNode child : children)
+                        {
+                            if (!isSectionNode(child))
+                            {
+                                filteredList.add(child);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        filteredList = children;
+                    }
+
+                    return filteredList;
+                }
+            };
+        }
+    }
+}

--- a/src/main/java/com/okta/tools/aws/settings/Configuration.java
+++ b/src/main/java/com/okta/tools/aws/settings/Configuration.java
@@ -16,7 +16,6 @@
 package com.okta.tools.aws.settings;
 
 import com.okta.tools.OktaAwsCliEnvironment;
-import org.ini4j.Profile;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -56,27 +55,23 @@ public class Configuration extends Settings {
     public void addOrUpdateProfile(String name, String roleToAssume, String region) {
         // profileName is the string used for the section in the AWS config file.
         // This should be prefixed with "profile ".
-        final String profileName = "default".equals(name) ? "default" : environment.profilePrefix + name;
+        String profileName = DEFAULT_PROFILE_NAME.equals(name) ? DEFAULT_PROFILE_NAME : environment.profilePrefix + name;
 
         // Determine whether this is a new AWS configuration file. If it is, we'll set the default
         // profile to this profile.
-        final boolean newConfig = settings.isEmpty();
-        if (newConfig) {
-            writeConfigurationProfile(settings.add(DEFAULTPROFILENAME), name, roleToAssume, region);
+        if (isEmpty()) {
+            writeConfigurationProfile(DEFAULT_PROFILE_NAME, name, roleToAssume, region);
         }
 
         // Write the new profile data
-        final Profile.Section awsProfile = settings.get(profileName) != null
-                ? settings.get(profileName)
-                : settings.add(profileName);
-        writeConfigurationProfile(awsProfile, name, roleToAssume, region);
+        writeConfigurationProfile(profileName, name, roleToAssume, region);
     }
 
-    private void writeConfigurationProfile(Profile.Section awsProfile, String name, String roleToAssume, String region) {
-        awsProfile.put(ROLE_ARN, roleToAssume);
-        awsProfile.put(SOURCE_PROFILE, "default".equals(name) ? "default" : name + environment.credentialsSuffix);
-        if (!awsProfile.containsKey(REGION)) {
-            awsProfile.put(REGION, region);
+    private void writeConfigurationProfile(String profile, String name, String roleToAssume, String region) {
+        setProperty(profile, ROLE_ARN, roleToAssume);
+        setProperty(profile, SOURCE_PROFILE, DEFAULT_PROFILE_NAME.equals(name) ? DEFAULT_PROFILE_NAME : name + environment.credentialsSuffix);
+        if (!containsProperty(profile, REGION)) {
+            setProperty(profile, REGION, region);
         }
     }
 }

--- a/src/main/java/com/okta/tools/aws/settings/Credentials.java
+++ b/src/main/java/com/okta/tools/aws/settings/Credentials.java
@@ -58,7 +58,7 @@ public class Credentials extends Settings {
      * @param awsSessionToken The session token to use for the profile.
      */
     public void addOrUpdateProfile(String name, String awsAccessKey, String awsSecretKey, String awsSessionToken) {
-        name = "default".equals(name) ? "default" : name + environment.credentialsSuffix;
+        name = DEFAULT_PROFILE_NAME.equals(name) ? DEFAULT_PROFILE_NAME : name + environment.credentialsSuffix;
         setProperty(name, ACCES_KEY_ID, awsAccessKey);
         setProperty(name, SECRET_ACCESS_KEY, awsSecretKey);
         setProperty(name, SESSION_TOKEN, awsSessionToken);

--- a/src/main/java/com/okta/tools/aws/settings/Credentials.java
+++ b/src/main/java/com/okta/tools/aws/settings/Credentials.java
@@ -16,7 +16,6 @@
 package com.okta.tools.aws.settings;
 
 import com.okta.tools.OktaAwsCliEnvironment;
-import org.ini4j.Profile;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -46,7 +45,7 @@ public class Credentials extends Settings {
         this.environment = environment;
     }
 
-    public Credentials(Reader reader) throws IOException {
+    Credentials(Reader reader) throws IOException {
         this(reader, new OktaAwsCliEnvironment());
     }
 
@@ -60,21 +59,8 @@ public class Credentials extends Settings {
      */
     public void addOrUpdateProfile(String name, String awsAccessKey, String awsSecretKey, String awsSessionToken) {
         name = "default".equals(name) ? "default" : name + environment.credentialsSuffix;
-        final Profile.Section awsProfile = settings.get(name) != null ? settings.get(name) : settings.add(name);
-        writeCredentialsProfile(awsProfile, awsAccessKey, awsSecretKey, awsSessionToken);
-    }
-
-    /**
-     * Create a new profile in this credentials object.
-     *
-     * @param awsProfile      A reference to the profile in the credentials.
-     * @param awsAccessKey    The AWS access key to use in the profile.
-     * @param awsSecretKey    The AWS secret access key to use in the profile.
-     * @param awsSessionToken The AWS session token to use in the profile.
-     */
-    private void writeCredentialsProfile(Profile.Section awsProfile, String awsAccessKey, String awsSecretKey, String awsSessionToken) {
-        awsProfile.put(ACCES_KEY_ID, awsAccessKey);
-        awsProfile.put(SECRET_ACCESS_KEY, awsSecretKey);
-        awsProfile.put(SESSION_TOKEN, awsSessionToken);
+        setProperty(name, ACCES_KEY_ID, awsAccessKey);
+        setProperty(name, SECRET_ACCESS_KEY, awsSecretKey);
+        setProperty(name, SESSION_TOKEN, awsSessionToken);
     }
 }

--- a/src/main/java/com/okta/tools/aws/settings/MultipleProfile.java
+++ b/src/main/java/com/okta/tools/aws/settings/MultipleProfile.java
@@ -51,12 +51,12 @@ public class MultipleProfile extends Settings {
     }
 
     private Instant getExpiry(String profile) {
-        String profileExpiry = getProperty(profile, "profile_expiry");
+        String profileExpiry = getProperty(profile, PROFILE_EXPIRY);
         return Instant.parse(profileExpiry);
     }
 
     private String getRoleArn(String profile) {
-        return getProperty(profile, "okta_roleArn");
+        return getProperty(profile, OKTA_ROLE_ARN);
     }
 
     /**

--- a/src/main/java/com/okta/tools/aws/settings/Settings.java
+++ b/src/main/java/com/okta/tools/aws/settings/Settings.java
@@ -15,22 +15,26 @@
  */
 package com.okta.tools.aws.settings;
 
-import org.ini4j.Config;
-import org.ini4j.Ini;
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.tree.ImmutableNode;
 
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * A simple abstract class used to load AWS CLI settings files like the `credentials` or `config` files.
  */
 public abstract class Settings {
 
-    final Ini settings = new Ini();
+    private final AwsINIConfiguration settings;
 
     // the name of the aws cli "default" profile
-    protected static final String DEFAULTPROFILENAME = "default";
+    static final String DEFAULT_PROFILE_NAME = "default";
 
     /**
      * Create a Settings object from a given {@link java.io.Reader}. The data given by this {@link java.io.Reader} should
@@ -40,9 +44,12 @@ public abstract class Settings {
      * @throws IOException Thrown when we cannot read or load from the given {@param reader}.
      */
     Settings(Reader reader) throws IOException {
-        // Don't escape special characters. By default ini4j escapes ':' to '\:', which is a problem in ARN's.
-        Config.getGlobal().setEscape(false);
-        settings.load(reader);
+        settings = new AwsINIConfiguration();
+        try {
+            settings.read(reader);
+        } catch (ConfigurationException e) {
+            throw new IOException(e);
+        }
     }
 
     /**
@@ -52,6 +59,40 @@ public abstract class Settings {
      * @throws IOException Thrown when we cannot write to {@param writer}.
      */
     public void save(Writer writer) throws IOException {
-        settings.store(writer);
+        try {
+            settings.write(writer);
+        } catch (ConfigurationException e) {
+            throw new IOException(e);
+        }
+    }
+
+    String getProperty(String section, String key) {
+        return settings.getSection(section).get(String.class, key);
+    }
+
+    void setProperty(String section, String key, String value) {
+        settings.getSection(section).setProperty(key, value);
+    }
+
+    void clearSection(String section) {
+        settings.getSection(section).clear();
+    }
+
+    boolean containsProperty(String section, String key) {
+        return settings.getSection(section).containsKey(key);
+    }
+
+    boolean isEmpty() {
+        return settings.isEmpty();
+    }
+
+    Set<String> getSections() {
+        return settings.getSections();
+    }
+
+    @VisibleForTesting
+    Map<String, Object> sectionToMap(String section) {
+        return settings.getSection(section).getNodeModel().getRootNode().getChildren().stream()
+                .collect(Collectors.toMap(ImmutableNode::getNodeName, ImmutableNode::getValue));
     }
 }

--- a/src/main/java/com/okta/tools/helpers/ConfigHelper.java
+++ b/src/main/java/com/okta/tools/helpers/ConfigHelper.java
@@ -3,9 +3,7 @@ package com.okta.tools.helpers;
 import com.okta.tools.OktaAwsCliEnvironment;
 import com.okta.tools.aws.settings.Configuration;
 
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.Reader;
 
 public final class ConfigHelper {
 
@@ -16,42 +14,15 @@ public final class ConfigHelper {
     }
 
     /**
-     * Gets a reader for the config file. If the file doesn't exist, it creates it
-     *
-     * @return A {@link Reader} for the config file
-     * @throws IOException
-     */
-    public Reader getConfigReader() throws IOException {
-        return FileHelper.getReader(FileHelper.getAwsDirectory(), "config");
-    }
-
-    /**
-     * Gets a FileWriter for the config file
-     *
-     * @return A {@link FileWriter} for the config file
-     * @throws IOException
-     */
-    public FileWriter getConfigWriter() throws IOException {
-        return FileHelper.getWriter(FileHelper.getAwsDirectory(), "config");
-    }
-
-    /**
      * Updates the configuration file
      *
-     * @throws IOException
+     * @throws IOException if a file system or permissions error occurs
      */
     public void updateConfigFile() throws IOException {
-        try (Reader reader = getConfigReader()) {
-            // Create the configuration object with the data from the config file
+        FileHelper.usingPath(FileHelper.getAwsDirectory().resolve("config"), (reader, writer) -> {
             Configuration configuration = new Configuration(reader, environment);
-
-            // Write the given profile data
             configuration.addOrUpdateProfile(environment.oktaProfile, environment.awsRoleToAssume, environment.awsRegion);
-
-            // Write the updated profile
-            try (FileWriter fileWriter = getConfigWriter()) {
-                configuration.save(fileWriter);
-            }
-        }
+            configuration.save(writer);
+        });
     }
 }

--- a/src/main/java/com/okta/tools/helpers/CookieHelper.java
+++ b/src/main/java/com/okta/tools/helpers/CookieHelper.java
@@ -9,7 +9,6 @@ import org.apache.http.impl.cookie.BasicClientCookie;
 
 import java.io.File;
 import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
@@ -84,7 +83,9 @@ public final class CookieHelper {
                 .filter(c -> environment.oktaOrg.equals(c.getDomain()))
                 .collect(Collectors.toMap(Cookie::getName, Cookie::getValue, (x, y) -> y))
                 .forEach(properties::setProperty);
-        properties.store(new FileWriter(getCookiesFilePath().toFile()), "");
+        FileHelper.writingPath(getCookiesFilePath(), writer ->
+                properties.store(writer, "")
+        );
     }
 
     void clearCookies() throws IOException {

--- a/src/main/java/com/okta/tools/helpers/CredentialsHelper.java
+++ b/src/main/java/com/okta/tools/helpers/CredentialsHelper.java
@@ -3,9 +3,7 @@ package com.okta.tools.helpers;
 import com.okta.tools.OktaAwsCliEnvironment;
 import com.okta.tools.aws.settings.Credentials;
 
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.Reader;
 
 public final class CredentialsHelper {
 
@@ -16,47 +14,20 @@ public final class CredentialsHelper {
     }
 
     /**
-     * Gets a reader for the credentials file. If the file doesn't exist, it creates it
-     *
-     * @return A {@link Reader} for the credentials file
-     * @throws IOException
-     */
-    public static Reader getCredsReader() throws IOException {
-        return FileHelper.getReader(FileHelper.getAwsDirectory(), "credentials");
-    }
-
-    /**
-     * Gets a FileWriter for the credentials file
-     *
-     * @return A {@link FileWriter} for the credentials file
-     * @throws IOException
-     */
-    public static FileWriter getCredsWriter() throws IOException {
-        return FileHelper.getWriter(FileHelper.getAwsDirectory(), "credentials");
-    }
-
-    /**
      * Updates the credentials file
      *
      * @param profileName     The profile to use
      * @param awsAccessKey    The access key to use
      * @param awsSecretKey    The secret key to use
      * @param awsSessionToken The session token to use
-     * @throws IOException
+     * @throws IOException    if a file system or permissions error occurs
      */
-    public void updateCredentialsFile(String profileName, String awsAccessKey, String awsSecretKey, String awsSessionToken)
+    void updateCredentialsFile(String profileName, String awsAccessKey, String awsSecretKey, String awsSessionToken)
             throws IOException {
-        try (Reader reader = CredentialsHelper.getCredsReader()) {
-            // Create the credentials object with the data read from the credentials file
+        FileHelper.usingPath(FileHelper.getAwsDirectory().resolve("credentials"), (reader, writer) -> {
             Credentials credentials = new Credentials(reader, environment);
-
-            // Write the given profile data
             credentials.addOrUpdateProfile(profileName, awsAccessKey, awsSecretKey, awsSessionToken);
-
-            // Write the updated profile
-            try (FileWriter fileWriter = CredentialsHelper.getCredsWriter()) {
-                credentials.save(fileWriter);
-            }
-        }
+            credentials.save(writer);
+        });
     }
 }

--- a/src/test/java/com/okta/tools/aws/settings/CredentialsTest.java
+++ b/src/test/java/com/okta/tools/aws/settings/CredentialsTest.java
@@ -23,7 +23,6 @@ import java.io.StringReader;
 import java.io.StringWriter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CredentialsTest {
 
@@ -49,14 +48,6 @@ class CredentialsTest {
                     null, null, null, null,
                     null, 0, null,
                     null, "_custom");
-
-    /*
-     * Test instantiating a Credentials object with invalid INI.
-     */
-    @Test
-    void instantiateInvalidCredentials() {
-        assertThrows(IOException.class, () -> new Credentials(new StringReader("someinvalidini")));
-    }
 
     /*
      * Test writing a new credentials profile to a blank credentials file.
@@ -202,19 +193,5 @@ class CredentialsTest {
         String given = org.apache.commons.lang.StringUtils.remove(credentialsWriter.toString().trim(), '\r');
 
         assertEquals(expected, given);
-    }
-
-    /*
-     * Tests whether the Reader given to the Credentials constructor is properly closed.
-     */
-    @Test
-    public void constructorClosesReader() throws Exception {
-        final String simpleIniDocument = "[ini]\nfoo=bar";
-        final StringReader reader = new StringReader(simpleIniDocument);
-
-        // This should consume reader
-        new Credentials(reader);
-        // Causing this to throw an exception
-        assertThrows(IOException.class, () -> reader.ready(), "Stream closed");
     }
 }

--- a/src/test/java/com/okta/tools/aws/settings/SettingsTest.java
+++ b/src/test/java/com/okta/tools/aws/settings/SettingsTest.java
@@ -1,0 +1,294 @@
+package com.okta.tools.aws.settings;
+
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SettingsTest {
+
+    private Settings settingsFromConfig(String config) throws IOException {
+        return new Settings(new StringReader(config)) {};
+    }
+
+    private String writeSettings(Settings settings) throws IOException {
+        StringWriter writer = new StringWriter();
+        settings.save(writer);
+        return writer.toString();
+    }
+
+    @Test
+    void save_EmptyAddsTrailingNewline() throws IOException {
+        Settings settings = settingsFromConfig(
+                ""
+        );
+        String writtenSettings = writeSettings(settings);
+        String expected =
+                "\n";
+        assertEquals(expected, writtenSettings);
+    }
+
+    @Test
+    void save_BlankStripsExtraTrailingNewlines() throws IOException {
+        Settings settings = settingsFromConfig(
+                "\n\n\n"
+        );
+        String writtenSettings = writeSettings(settings);
+        String expected =
+                "\n";
+        assertEquals(expected, writtenSettings);
+    }
+
+    @Test
+    void save_WithContentAddsTrailingNewline() throws IOException {
+        Settings settings = settingsFromConfig(
+                "key=value"
+        );
+        String writtenSettings = writeSettings(settings);
+        String expected =
+                "key = value\n" +
+                "\n";
+        assertEquals(expected, writtenSettings);
+    }
+
+    @Test
+    void save_PreservesNestedProperties() throws IOException {
+        Settings settings = settingsFromConfig(
+                "[profile development]\n" +
+                "aws_access_key_id=foo\n" +
+                "aws_secret_access_key=bar\n" +
+                "s3 =\n" +
+                "  max_concurrent_requests = 20\n" +
+                "  max_queue_size = 10000\n" +
+                "\n"
+        );
+        String writtenSettings = writeSettings(settings);
+        // Extra spaces in the output appear not to affect AWS CLI
+        String expected =
+                "[profile development]\n" +
+                "aws_access_key_id = foo\n" + // DIVERGENCE: extra space
+                "aws_secret_access_key = bar\n" + // DIVERGENCE: extra space
+                "s3 = \n" + // DIVERGENCE: extra space
+                "  max_concurrent_requests = 20\n" +
+                "  max_queue_size = 10000\n" +
+                "\n";
+        assertEquals(expected, writtenSettings);
+    }
+
+    @Test
+    void getProperty_FromGlobal() throws IOException {
+        Settings settings = settingsFromConfig(
+                "key=value\n" +
+                "\n"
+        );
+        String actualValue = settings.getProperty(null, "key");
+        String expectedValue = "value";
+        assertEquals(expectedValue, actualValue);
+    }
+
+
+    @Test
+    void getProperty_InSection() throws IOException {
+        Settings settings = settingsFromConfig(
+                "[myCoolSection]\n" +
+                "key=value\n" +
+                "\n"
+        );
+        String actualValue = settings.getProperty("myCoolSection", "key");
+        String expectedValue = "value";
+        assertEquals(expectedValue, actualValue);
+    }
+
+    @Test
+    void getProperty_NullWhenDoesntExist() throws IOException {
+        Settings settings = settingsFromConfig(
+                "[myCoolSection]\n" +
+                "key=value\n" +
+                "\n"
+        );
+        String actualValue = settings.getProperty("myCoolSection", "keyNotThere");
+        assertNull(actualValue);
+    }
+
+    @Test
+    void getProperty_EmptyWhenNoValue() throws IOException {
+        Settings settings = settingsFromConfig(
+                "[myCoolSection]\n" +
+                "key\n" +
+                "\n"
+        );
+        String actualValue = settings.getProperty("myCoolSection", "key");
+        String expectedValue = "";
+        assertEquals(expectedValue, actualValue);
+    }
+
+    @Test
+    void getProperty_EmptyWhenBlankValue() throws IOException {
+        Settings settings = settingsFromConfig(
+                "[myCoolSection]\n" +
+                "key=\n" +
+                "\n"
+        );
+        String actualValue = settings.getProperty("myCoolSection", "key");
+        String expectedValue = "";
+        assertEquals(expectedValue, actualValue);
+    }
+
+    // Don't use this for reading nested properties (sadness will ensue)
+    @Test
+    void getProperty_FirstNestedPropertyWins() throws IOException {
+        Settings settings = settingsFromConfig(
+                "[profile development]\n" +
+                "aws_access_key_id=foo\n" +
+                "aws_secret_access_key=bar\n" +
+                "s3 =\n" +
+                "  max_concurrent_requests = 20\n" +
+                "  max_queue_size = 10000\n" +
+                "dynamodb =\n" +
+                "  max_concurrent_requests = 30\n" +
+                "\n"
+        );
+        // Nested properties are preserved, but getting them is not supported
+        // If you need this, roll up your sleeves and add it to AwsINIConfiguration
+        String actualValue = settings.getProperty("profile development", "  max_concurrent_requests");
+        String expectedValue = "20";
+        assertEquals(expectedValue, actualValue);
+    }
+
+    @Test
+    void setProperty_CanBeGotten() throws IOException {
+        Settings settings = settingsFromConfig(
+                ""
+        );
+        settings.setProperty("default", "key", "value");
+        String actualValue = settings.getProperty("default", "key");
+        String expectedValue = "value";
+        assertEquals(expectedValue, actualValue);
+    }
+
+    @Test
+    void setProperty_WrittenToFile() throws IOException {
+        Settings settings = settingsFromConfig(
+                ""
+        );
+        settings.setProperty("default", "key", "value");
+        String writtenSettings = writeSettings(settings);
+        String expected =
+                "[default]\n" +
+                "key = value\n" +
+                "\n";
+        assertEquals(expected, writtenSettings);
+    }
+
+    // Don't use this for editing nested properties (sadness will ensue)
+    @Test
+    void setProperty_WritingNestedProperties() throws IOException {
+        Settings settings = settingsFromConfig(
+                "[profile development]\n" +
+                "s3 =\n" +
+                "  max_queue_size = 10000\n" +
+                "aws_access_key_id=foo\n" +
+                "aws_secret_access_key=bar\n" +
+                "\n"
+        );
+        // Nested properties are preserved, but setting them is not supported
+        settings.setProperty("profile development", "  max_concurrent_requests", "30");
+        String writtenSettings = writeSettings(settings);
+        // Extra spaces in the output appear not to affect AWS CLI
+        String expected =
+                "[profile development]\n" +
+                "s3 = \n" + // DIVERGENCE: extra space
+                "  max_queue_size = 10000\n" +
+                "aws_access_key_id = foo\n" + // DIVERGENCE: extra space
+                "aws_secret_access_key = bar\n" + // DIVERGENCE: extra space
+                "  max_concurrent_requests = 30\n" + // WAT! This is not what you likely wanted
+                "\n";
+        assertEquals(expected, writtenSettings);
+    }
+
+    @Test
+    void clearSection() throws IOException {
+        Settings settings = settingsFromConfig(
+                "[myCoolSection]\n" +
+                "stuffInSection=isAlsoCool\n" +
+                "[anotherSection]\n"
+        );
+        settings.clearSection("myCoolSection");
+        String writtenSettings = writeSettings(settings);
+        String expected =
+                "[anotherSection]\n" +
+                "\n";
+        assertEquals(expected, writtenSettings);
+    }
+
+    @Test
+    void containsProperty() throws IOException {
+        Settings settings = settingsFromConfig(
+                "[myCoolSection]\n" +
+                "stuffInSection=isAlsoCool\n" +
+                "[anotherSection]\n"
+        );
+        assertTrue(settings.containsProperty("myCoolSection", "stuffInSection"));
+    }
+
+    @Test
+    void isEmpty_TrueOnBlankConfig() throws IOException {
+        Settings settings = settingsFromConfig(
+                ""
+        );
+        assertTrue(settings.isEmpty());
+    }
+
+    @Test
+    void isEmpty_FalseOnTrivialConfig() throws IOException {
+        Settings settings = settingsFromConfig(
+                "key=value"
+        );
+        assertFalse(settings.isEmpty());
+    }
+
+    @Test
+    void getSections() throws IOException {
+        Settings settings = settingsFromConfig(
+                "[myCoolSection]\n" +
+                "stuffInSection=isAlsoCool\n" +
+                "[anotherSection]\n"
+        );
+        Set<String> sections = settings.getSections();
+        assertEquals(sections.size(), 2);
+        assertTrue(sections.contains("myCoolSection"));
+        assertTrue(sections.contains("anotherSection"));
+    }
+
+    @Test
+    void sectionToMap_EmptyOnEmptySection() throws IOException {
+        Settings settings = settingsFromConfig(
+                "[myCoolSection]\n" +
+                "stuffInSection=isAlsoCool\n" +
+                "moreStuff=isLessCool\n" +
+                "[anotherSection]\n"
+        );
+        Map<String, Object> anotherSection = settings.sectionToMap("anotherSection");
+        assertTrue(anotherSection.isEmpty());
+    }
+
+    @Test
+    void sectionToMap_HasAllAndOnlySectionProperties() throws IOException {
+        Settings settings = settingsFromConfig(
+                "[myCoolSection]\n" +
+                "stuffInSection=isAlsoCool\n" +
+                "moreStuff=isLessCool\n" +
+                "[anotherSection]\n"
+        );
+        Map<String, Object> myCoolSection = settings.sectionToMap("myCoolSection");
+        assertEquals(myCoolSection.size(), 2);
+        assertTrue(myCoolSection.containsKey("stuffInSection"));
+        assertEquals("isAlsoCool", myCoolSection.get("stuffInSection"));
+        assertEquals("isLessCool", myCoolSection.get("moreStuff"));
+    }
+}


### PR DESCRIPTION
Problem Statement
-----------------

Issue #141 states:
> Existing `~/.aws/config` with nested properties are overwritten improperly by this tool.
> For example, `s3` configuration uses [indentation for its properties](https://docs.aws.amazon.com/cli/latest/topic/s3-config.html) e.g.
> ```
> [profile development]
> aws_access_key_id=foo
> aws_secret_access_key=bar
> s3 =
>   max_concurrent_requests = 20
>   max_queue_size = 10000
> ```
> When `awscli` is run, the `config` is written out like so:
> ```
> [profile development]
> aws_access_key_id=foo
> aws_secret_access_key=bar
> s3 =
> max_concurrent_requests = 20
> max_queue_size = 10000
> ```
> which is not correctly read by `aws s3` commands!
> 
> Specifically, the following test https://github.com/oktadeveloper/okta-aws-cli-assume-role/blob/054c45c5b0b58195db45bd25b528c0436331d7ed/src/test/java/com/okta/tools/aws/settings/ConfigurationTest.java#L110-L130 if modified to contain s3 keys as follows:
> ```java
>     @Test
>     void addOrUpdateProfileToExistingProfile() throws IOException {
>         final String existingCombined = manualRole + "\n"
>                 + "s3 =\n"
>                 + "    max_queue_size = 1000" + "\n\n" + existingProfile;
> 
>         final StringReader configurationReader = new StringReader(existingCombined);
>         final StringWriter configurationWriter = new StringWriter();
>         final Configuration configuration = new Configuration(configurationReader);
> 
>         final String updatedPrefix = "updated_";
>         final String expected = "[profile " + profileName + "]\n"
>                 + Configuration.ROLE_ARN + " = " + updatedPrefix + role_arn + "\n"
>                 + SOURCE_PROFILE + " = " + profileName + "_source\n"
>                 + Configuration.REGION + " = " + region + "\n"
>                 + "s3 =\n"
>                 + "    max_queue_size = 1000"
>                 + "\n\n" + existingProfile;
> 
> 
>         configuration.addOrUpdateProfile(profileName, updatedPrefix + role_arn);
>         configuration.save(configurationWriter);
> 
>         String given = StringUtils.remove(configurationWriter.toString().trim(), '\r');
> 
>         assertEquals(expected, given);
>     }
> ```
> will not pass.

Solution
--------
 - Add Apache Commons Configuration2

 - Adapt configuration2's INIConfiguration to support AWS quirks

 - Remove Ini4j (unmaintained, has park page for website)

 - Refactor file handling code

Resolves #141

Apologies for the extensiveness of this change. The configuration
handling likely needs a refactor to make it easier to support future
modification.