### PR TITLE
:lock: Remove plaintext saved password support

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -115,6 +115,7 @@ Here is the list of parameters that can be environment variables or settings in 
   - ```OKTA_ORG``` which is the url of your Okta org (starting with https://).
   - ```OKTA_AWS_APP_URL``` is the url link of your Okta AWS application url (see below for more info) 
   - ```OKTA_USERNAME``` is the username to use. If present will skip username input.
+  - ```OKTA_PASSWORD_CMD``` is the command to fetch your password instead of showing a password prompt. [Read more...](docs/OKTA_PASSWORD_CMD.md)  
   - ```OKTA_BROWSER_AUTH``` set to **true** to use integrated web browser for authentication (default: **false**)
   - ```OKTA_COOKIES_PATH``` is directory path to store cookies.properties for Okta (default: ~/.okta)
   - ```OKTA_PROFILE``` is the name of the AWS profile to create/reuse.  May also be specified on the commandline by ```--profile```. (default: get AWS profile name based on per-session STS user name)  

--- a/Readme.MD
+++ b/Readme.MD
@@ -115,7 +115,6 @@ Here is the list of parameters that can be environment variables or settings in 
   - ```OKTA_ORG``` which is the url of your Okta org (starting with https://).
   - ```OKTA_AWS_APP_URL``` is the url link of your Okta AWS application url (see below for more info) 
   - ```OKTA_USERNAME``` is the username to use. If present will skip username input.
-  - ```OKTA_PASSWORD``` is the password to use. If present will skip password input.
   - ```OKTA_BROWSER_AUTH``` set to **true** to use integrated web browser for authentication (default: **false**)
   - ```OKTA_COOKIES_PATH``` is directory path to store cookies.properties for Okta (default: ~/.okta)
   - ```OKTA_PROFILE``` is the name of the AWS profile to create/reuse.  May also be specified on the commandline by ```--profile```. (default: get AWS profile name based on per-session STS user name)  

--- a/docs/OKTA_PASSWORD_CMD.md
+++ b/docs/OKTA_PASSWORD_CMD.md
@@ -1,0 +1,11 @@
+# OKTA_PASSWORD_CMD Documentation
+
+## Help wanted!
+
+Please contribute additional examples for your favored platform or password manager.
+
+## Example: macOS KeyChain
+
+1. Create password entry `security add-generic-password -a $OKTA_USERNAME -s okta-aws-cli -T /usr/bin/security -U`
+2. Launch KeyChain Access and search for **okta-aws-cli**
+3. Set OKTA_PASSWORD_CMD to `security find-generic-password -a $OKTA_USERNAME -s okta-aws-cli -w`

--- a/src/main/java/com/okta/tools/OktaAwsConfig.java
+++ b/src/main/java/com/okta/tools/OktaAwsConfig.java
@@ -51,7 +51,7 @@ final class OktaAwsConfig {
                 Boolean.valueOf(getEnvOrConfig(properties, "OKTA_BROWSER_AUTH")),
                 getEnvOrConfig(properties, "OKTA_ORG"),
                 getEnvOrConfig(properties, "OKTA_USERNAME"),
-                getEnvOrConfig(properties, "OKTA_PASSWORD"),
+                null,
                 getEnvOrConfig(properties, "OKTA_COOKIES_PATH"),
                 getProfile(profile, getEnvOrConfig(properties, "OKTA_PROFILE")),
                 getEnvOrConfig(properties, "OKTA_AWS_APP_URL"),


### PR DESCRIPTION
Problem Statement
-----------------
OKTA_PASSWORD is not stored securely. Having this feature in is a
security risk for users.

Solution
--------
 - Remove documentation for OKTA_PASSWORD

 - Remove support for OKTA_PASSWORD

Resolves #171

Will revisit with support for a password command as recommended in #12
