### PR TITLE
:seedling: Add support for EnvVars integration

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -118,7 +118,7 @@ Here is the list of parameters that can be environment variables or settings in 
   - ```OKTA_PASSWORD_CMD``` is the command to fetch your password instead of showing a password prompt. [Read more...](docs/OKTA_PASSWORD_CMD.md)
   - ```OKTA_ENV_MODE``` set to **true** to run sub-command with **AWS_ACCESS_KEY_ID**, **AWS_SECRET_ACCESS_KEY**, and **AWS_SESSION_TOKEN** env vars set. Temporary credentials are shared in memory and kept off disk in this mode. (default: **false**)
   - ```OKTA_BROWSER_AUTH``` set to **true** to use integrated web browser for authentication (default: **false**)
-  - ```OKTA_COOKIES_PATH``` is directory path to store cookies.properties for Okta (default: ~/.okta)
+  - ```OKTA_COOKIES_PATH``` is directory path to store cookies.properties for Okta. This is particularly useful when running this tool in many concurrent processes like you might with **OKTA_ENV_MODE** (default: ~/.okta)
   - ```OKTA_PROFILE``` is the name of the AWS profile to create/reuse.  May also be specified on the commandline by ```--profile```. (default: get AWS profile name based on per-session STS user name)  
   - ```OKTA_AWS_REGION``` is the default AWS region to store with the created profile.
   - ```OKTA_AWS_ROLE_TO_ASSUME``` is the role to use. If present will try to match okta account's retrieved role list and use it. Will still prompt if no match found.

--- a/Readme.MD
+++ b/Readme.MD
@@ -115,7 +115,8 @@ Here is the list of parameters that can be environment variables or settings in 
   - ```OKTA_ORG``` which is the url of your Okta org (starting with https://).
   - ```OKTA_AWS_APP_URL``` is the url link of your Okta AWS application url (see below for more info) 
   - ```OKTA_USERNAME``` is the username to use. If present will skip username input.
-  - ```OKTA_PASSWORD_CMD``` is the command to fetch your password instead of showing a password prompt. [Read more...](docs/OKTA_PASSWORD_CMD.md)  
+  - ```OKTA_PASSWORD_CMD``` is the command to fetch your password instead of showing a password prompt. [Read more...](docs/OKTA_PASSWORD_CMD.md)
+  - ```OKTA_ENV_MODE``` set to **true** to run sub-command with **AWS_ACCESS_KEY_ID**, **AWS_SECRET_ACCESS_KEY**, and **AWS_SESSION_TOKEN** env vars set. Temporary credentials are shared in memory and kept off disk in this mode. (default: **false**)
   - ```OKTA_BROWSER_AUTH``` set to **true** to use integrated web browser for authentication (default: **false**)
   - ```OKTA_COOKIES_PATH``` is directory path to store cookies.properties for Okta (default: ~/.okta)
   - ```OKTA_PROFILE``` is the name of the AWS profile to create/reuse.  May also be specified on the commandline by ```--profile```. (default: get AWS profile name based on per-session STS user name)  

--- a/src/main/java/com/okta/tools/OktaAwsCliEnvironment.java
+++ b/src/main/java/com/okta/tools/OktaAwsCliEnvironment.java
@@ -1,5 +1,7 @@
 package com.okta.tools;
 
+import java.util.function.Supplier;
+
 public class OktaAwsCliEnvironment {
     private static final String DEFAULT_PROFILE_PREFIX = "profile ";
     private static final String DEFAULT_CREDENTIALS_SUFFIX = "_source";
@@ -7,7 +9,7 @@ public class OktaAwsCliEnvironment {
     public final boolean browserAuth;
     public final String oktaOrg;
     public final String oktaUsername;
-    public final String oktaPassword;
+    public final Supplier<String> oktaPassword;
     public final String oktaCookiesPath;
     public String oktaProfile;
 
@@ -18,18 +20,19 @@ public class OktaAwsCliEnvironment {
     public int stsDuration;
     public final String awsRegion;
     public final String profilePrefix;
+    public final boolean oktaEnvMode;
     public final String credentialsSuffix;
 
     public OktaAwsCliEnvironment()
     {
-        this(false, null, null, null, null, null, null, null, 0, null, null, null);
+        this(false, null, null, null, null, null, null, null, 0, null, null, false, null);
     }
 
     public OktaAwsCliEnvironment(boolean browserAuth, String oktaOrg,
-                                 String oktaUsername, String oktaPassword, String oktaCookiesPath,
+                                 String oktaUsername, Supplier<String> oktaPassword, String oktaCookiesPath,
                                  String oktaProfile, String oktaAwsAppUrl, String awsRoleToAssume,
                                  int stsDuration, String awsRegion, String profilePrefix,
-                                 String credentialsSuffix) {
+                                 boolean oktaEnvMode, String credentialsSuffix) {
         this.browserAuth = browserAuth;
         this.oktaOrg = oktaOrg;
         this.oktaUsername = oktaUsername;
@@ -41,6 +44,7 @@ public class OktaAwsCliEnvironment {
         this.stsDuration = stsDuration;
         this.awsRegion = awsRegion;
         this.profilePrefix = profilePrefix == null ? DEFAULT_PROFILE_PREFIX : profilePrefix;
+        this.oktaEnvMode = oktaEnvMode;
         this.credentialsSuffix = credentialsSuffix == null ? DEFAULT_CREDENTIALS_SUFFIX : credentialsSuffix;
     }
 }

--- a/src/main/java/com/okta/tools/authentication/OktaAuthentication.java
+++ b/src/main/java/com/okta/tools/authentication/OktaAuthentication.java
@@ -188,10 +188,10 @@ public final class OktaAuthentication {
     }
 
     private String getPassword() {
-        if (environment.oktaPassword == null || environment.oktaPassword.isEmpty()) {
+        if (environment.oktaPassword == null) {
             return promptForPassword();
         } else {
-            return environment.oktaPassword;
+            return environment.oktaPassword.get();
         }
     }
 

--- a/src/main/java/com/okta/tools/helpers/ProfileHelper.java
+++ b/src/main/java/com/okta/tools/helpers/ProfileHelper.java
@@ -17,7 +17,7 @@ public class ProfileHelper {
         this.environment = environment;
     }
 
-    public String createAwsProfile(AssumeRoleWithSAMLResult assumeResult) throws IOException {
+    public void createAwsProfile(AssumeRoleWithSAMLResult assumeResult, String credentialsProfileName) throws IOException {
         BasicSessionCredentials temporaryCredentials =
                 new BasicSessionCredentials(
                         assumeResult.getCredentials().getAccessKeyId(),
@@ -28,13 +28,10 @@ public class ProfileHelper {
         String awsSecretKey = temporaryCredentials.getAWSSecretKey();
         String awsSessionToken = temporaryCredentials.getSessionToken();
 
-        String credentialsProfileName = getProfileName(assumeResult, environment.oktaProfile);
         credentialsHelper.updateCredentialsFile(credentialsProfileName, awsAccessKey, awsSecretKey, awsSessionToken);
-
-        return credentialsProfileName;
     }
 
-    private String getProfileName(AssumeRoleWithSAMLResult assumeResult, String oktaProfile) {
+    public String getProfileName(AssumeRoleWithSAMLResult assumeResult, String oktaProfile) {
         String credentialsProfileName;
         if (StringUtils.isNotBlank(oktaProfile)) {
             credentialsProfileName = oktaProfile;

--- a/src/test/java/com/okta/tools/aws/settings/ConfigurationTest.java
+++ b/src/test/java/com/okta/tools/aws/settings/ConfigurationTest.java
@@ -54,7 +54,7 @@ class ConfigurationTest {
     private OktaAwsCliEnvironment environmentWithCustomPrefix =
             new OktaAwsCliEnvironment(false, null, null,
                     null, null, null, null, null,
-                    0, null, "custom ", null);
+                    0, null, "custom ", false, null);
 
     /*
      * Test writing a new profile to a blank configuration file.

--- a/src/test/java/com/okta/tools/aws/settings/CredentialsTest.java
+++ b/src/test/java/com/okta/tools/aws/settings/CredentialsTest.java
@@ -47,7 +47,7 @@ class CredentialsTest {
             new OktaAwsCliEnvironment(false, null, null,
                     null, null, null, null,
                     null, 0, null,
-                    null, "_custom");
+                    null, false, "_custom");
 
     /*
      * Test writing a new credentials profile to a blank credentials file.


### PR DESCRIPTION
Problem Statement
-----------------
#177 states:
> It'd be handy if there's an option to export "AWS_ACCESS_KEY_ID, AWS_SECRET_KEY, AWS_SESSION_TOKEN" as EnvVars in lieu of writing to the AWS profiles file.
>
>Use case would be for any tools that can load auth from those EnvVars.

Solution
--------
 - Introduce OKTA_ENV_MODE

 - Add documentation for OKTA_ENV_MODE

 - Run sub-process with env vars instead of saved profiles

 - :bug: Defer password command

Resolves #177

