### PR TITLE
:bug: Release version is hard-coded in bin/install.sh

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -27,7 +27,9 @@ then
 fi
 
 mkdir -p ${HOME}/.okta
-curl -L 'https://github.com/oktadeveloper/okta-aws-cli-assume-role/releases/download/v1.0.2/okta-aws-cli-1.0.2.jar' --output "${HOME}/.okta/okta-aws-cli.jar"
+releaseUrl=$(curl --head --silent https://github.com/oktadeveloper/okta-aws-cli-assume-role/releases/latest | grep 'Location:' | cut -c11-)
+releaseTag=$(echo $releaseUrl | awk 'BEGIN{FS="/"}{print $8}' | tr -d '\r')
+curl -L "https://github.com/oktadeveloper/okta-aws-cli-assume-role/releases/download/${releaseTag}/okta-aws-cli-${releaseTag:1}.jar" --output "${HOME}/.okta/okta-aws-cli.jar"
 
 # bash functions
 bash_functions="${HOME}/.okta/bash_functions"


### PR DESCRIPTION
Problem Statement
-----------------
Issue #187 states:

> **Is your feature request related to a problem? Please describe.**
> Currently, the install.sh is hard-coded to install the v1.0.2 release. We recently released v1.0.3. The install.sh script should default to the latest release version.
> 
> **Describe the solution you'd like**
> It would probably make sense to have a simple file like latest.txt that stores the latest release version that install.sh could refer to. latest.txt would have to be manually updated whenever we do a new release.
> 
> **Describe alternatives you've considered**
> I can't think of a more automated way to do this, but there probably is one.
> 
> **Additional context**
> It seems like the install.sh script is becoming the preferred way to install the tool, which is great, so we should make sure that we are installing the latest version.

Solution
--------
This should probably be replaced with GitHub GraphQL at some point, but
the authentication and OAuth key management makes it complicated.

 - Determine latest release from URL and download it

Resolves #187
