### PR TITLE
:bug: AWS Bash wrapper is broken

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -38,7 +38,7 @@ if [ $? -ne 0 ]
 then
 echo '
 function aws {
-    withokta aws $@
+    withokta "aws --profile $1" $@
 }
 ' >> "${bash_functions}"
 fi


### PR DESCRIPTION
Problem Statement
-----------------
Issue #194 states:
> Hi Okta Devs,
> 
> Thanks for your work to get the okta-aws-cli-assume-role tool running, this is critical for my organization to be able to leverage the Okta/AWS integration.
> 
> I'm having some trouble understanding the CLI syntax and profile naming.  Starting with a fresh okta-aws-cli-assume-role and no `~/.aws/credentials` file, I ran:
> 
> ```bash
> $ aws prod sts get-caller-identity
> ```
> I'm using `"OKTA_BROWSER_AUTH=true"`, so it popped open the java browser, and I went through the authentication steps.
> 
> Then I ran:
> ```bash
> $ aws prod s3 ls [my s3 bucket]
> ```
> 
> And got:
> 
> > The source_profile "test_source" referenced in the profile "default" does not exist.
> 
> Running the exact same commands with "aws test..." works fine!  I was expecting the arg after "aws" to be an arbitrary session profile name, but it seems to work with "test" but not with "prod".
> 
> Am I doing something wrong?  Is my understandfing of that argument incorrect?  Is there more documentation somewhere that lays out how this is supposed to work?  (I've only read the README on the okta-aws-cli-assume-role repo).
> 
> I'm testing on:
> 
> - OS X 10.13.3
> - java 10.0.2 2018-07-17
> - okta-aws-cli-assume-role 1.0.3
> 
> Thanks for taking a look!

Solution
--------
 - Send the correct profile args to withokta

Resolves #194

