### PR TITLE
Add multi module docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:latest as builder
+
+RUN apt-get update && \
+    apt-get install -y openjdk-8-jdk openjfx && \
+    apt-get install -y maven
+
+ADD . okta-aws-cli
+
+RUN cd okta-aws-cli && \
+    mvn package && \
+    cp target/okta-aws-cli-*.jar out/oktaawscli.jar
+
+FROM openjdk:8-jre-alpine
+
+# Versions: https://pypi.python.org/pypi/awscli#downloads
+ENV AWS_CLI_VERSION 1.16.7
+
+RUN apk --no-cache add python py-pip ca-certificates groff less && \
+    pip --no-cache-dir install awscli==${AWS_CLI_VERSION}
+
+COPY --from=builder /okta-aws-cli/out/ /okta
+
+WORKDIR /okta
+ENTRYPOINT ["sh", "awscli"]

--- a/Readme.MD
+++ b/Readme.MD
@@ -53,9 +53,18 @@ This tool has been verified to work on macOS Sierra, High Sierra, Windows Server
    OKTA_ORG=acmecorp.oktapreview.com
    OKTA_AWS_APP_URL=https://acmecorp.oktapreview.com/home/amazon_aws/0oa5zrwfs815KJmVF0h7/137
    ```
-2. Run this command:
+2. Build the image locally using:
    ```shell
-   docker run -v ~/.okta/config.properties:/root/.okta/config.properties -it tomsmithokta/okta-awscli-java
+   docker build okta-awscli-java .
+   ```
+
+3. Run via:
+   ```shell
+   docker run -it --rm -v ~/.okta/config.properties:/root/.okta/config.properties okta-awscli-java
+   ```
+   Or alternatively, to have okta update your local aws config as well,
+   ```shell
+   docker run -it --rm -v ~/.aws/:/root/.aws/ -v ~/.okta/config.properties:/root/.okta/config.properties okta-awscli-java
    ```
 
 Read more at [@tom-smith-okta's okta-awscli-java Docker repo](https://hub.docker.com/r/tomsmithokta/okta-awscli-java/).


### PR DESCRIPTION
Problem Statement
-----------------
Support docker as a first class citizen for building and deploying. The current Docker story depends on an external repo pushing up to date images (thanks @tom-smith-okta!).


Solution
--------
Builds on the work in #188 and adds a Dockerfile that builds a minimally sized image to run the latest cli. The build leverages multi module docker building to separate the java build dependencies (jdk + maven) from the runtime ones (aws cli + jre) and keep the size small. Ideally, this Dockerfile can then be used as an [automated build](https://docs.docker.com/docker-hub/builds/) on docker hub. 

