### PR TITLE
:bug: Requires sudo to install on CentOS

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+PREFIX=${PREFIX:=/usr/local}
 
 java -version > /dev/null 2>&1
 if [ $? -ne 0 ];
@@ -85,8 +86,8 @@ profile=$2
 shift;
 shift;
 env OKTA_PROFILE=$profile java -classpath ~/.okta/okta-aws-cli.jar com.okta.tools.WithOkta $command $@
-' > "/usr/local/bin/withokta"
-chmod +x "/usr/local/bin/withokta"
+' > "$PREFIX/bin/withokta"
+chmod +x "$PREFIX/bin/withokta"
 
 # Configure Okta AWS CLI
 oktaConfig="${HOME}/.okta/config.properties"


### PR DESCRIPTION
Problem Statement
-----------------
Issue #175 states:

> When following the installation instructions the install shell script fails here due to insufficient priveleges:
> https://github.com/oktadeveloper/okta-aws-cli-assume-role/blob/master/bin/install.sh#L80-L86
> 
> Should this command be run with `sudo`?

Solution
--------
 - Provide overridable PREFIX (default /usr/local)

Resolves #175

