### PR TITLE
:seedling: Support for credential_process

### DIFF
--- a/src/main/java/com/okta/tools/CredentialProcess.java
+++ b/src/main/java/com/okta/tools/CredentialProcess.java
@@ -1,0 +1,50 @@
+package com.okta.tools;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+/*
+ * Copyright 2017 Okta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public class CredentialProcess {
+    public static void main(String[] args) throws Exception {
+        OktaAwsCliEnvironment environment = OktaAwsConfig.loadEnvironment();
+        Instant startInstant = Instant.now();
+        Duration sessionLength = Duration.of(environment.stsDuration, ChronoUnit.SECONDS);
+        Instant expirationInstant = startInstant.plus(sessionLength);
+        OktaAwsCliAssumeRole.RunResult runResult = OktaAwsCliAssumeRole.withEnvironment(environment).run(startInstant);
+        Credential credential = new Credential();
+        credential.Version = 1;
+        credential.AccessKeyId = runResult.accessKeyId;
+        credential.SecretAccessKey = runResult.secretAccessKey;
+        credential.SessionToken = runResult.sessionToken;
+        credential.Expiration = expirationInstant.toString();
+        ObjectMapper objectMapper = new ObjectMapper();
+        String credentialJson = objectMapper.writeValueAsString(credential);
+        System.out.println(credentialJson);
+    }
+
+    public static class Credential {
+        public int Version;
+        public String AccessKeyId;
+        public String SecretAccessKey;
+        public String SessionToken;
+        public String Expiration;
+    }
+}

--- a/src/main/java/com/okta/tools/LogoutHandler.java
+++ b/src/main/java/com/okta/tools/LogoutHandler.java
@@ -4,7 +4,7 @@ final class LogoutHandler {
     static boolean handleLogout(String[] args) throws Exception {
         if (args.length > 0 && "logout".equals(args[0])) {
             OktaAwsCliAssumeRole.withEnvironment(OktaAwsConfig.loadEnvironment()).logoutSession();
-            System.out.println("You have been logged out");
+            System.err.println("You have been logged out");
             System.exit(0);
             return true;
         }

--- a/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
+++ b/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
@@ -81,7 +81,7 @@ final class OktaAwsCliAssumeRole {
     RunResult run(Instant startInstant) throws Exception {
         init();
 
-        environment.awsRoleToAssume = currentProfile.map(profile1 -> profile1.roleArn).orElse(null);
+        environment.awsRoleToAssume = currentProfile.map(profile1 -> profile1.roleArn).orElse(environment.awsRoleToAssume);
 
         if (currentSession.isPresent() && sessionHelper.sessionIsActive(startInstant, currentSession.get()) &&
                 StringUtils.isBlank(environment.oktaProfile)) {

--- a/src/main/java/com/okta/tools/authentication/OktaAuthentication.java
+++ b/src/main/java/com/okta/tools/authentication/OktaAuthentication.java
@@ -179,10 +179,10 @@ public final class OktaAuthentication {
 
     private String getUsername() {
         if (environment.oktaUsername == null || environment.oktaUsername.isEmpty()) {
-            System.out.print("Username: ");
+            System.err.print("Username: ");
             return new Scanner(System.in).next();
         } else {
-            System.out.println("Username: " + environment.oktaUsername);
+            System.err.println("Username: " + environment.oktaUsername);
             return environment.oktaUsername;
         }
     }
@@ -197,7 +197,7 @@ public final class OktaAuthentication {
 
     private String promptForPassword() {
         if (System.console() == null) { // hack to be able to debug in an IDE
-            System.out.print("Password: ");
+            System.err.print("Password: ");
             return new Scanner(System.in).next();
         } else {
             return new String(System.console().readPassword("Password: "));

--- a/src/main/java/com/okta/tools/authentication/OktaMFA.java
+++ b/src/main/java/com/okta/tools/authentication/OktaMFA.java
@@ -75,10 +75,10 @@ public class OktaMFA {
      */
     private static String handleTimeoutsAndChanges(String sessionToken, JSONObject primaryAuthResponse) {
         if (sessionToken.equals("change factor")) {
-            System.out.println("Factor change initiated");
+            System.err.println("Factor change initiated");
             return promptForFactor(primaryAuthResponse);
         } else if (sessionToken.equals("timeout")) {
-            System.out.println("Factor timed out");
+            System.err.println("Factor timed out");
             return promptForFactor(primaryAuthResponse);
         }
         return sessionToken;
@@ -105,13 +105,13 @@ public class OktaMFA {
         }
 
         if (supportedFactors.size() > 1) {
-            System.out.println("\nMulti-Factor authentication is required. Please select a factor to use.");
-            System.out.println("Factors:");
+            System.err.println("\nMulti-Factor authentication is required. Please select a factor to use.");
+            System.err.println("Factors:");
             for (int i = 0; i < supportedFactors.size(); i++) {
                 JSONObject factor = supportedFactors.get(i);
                 factorType = factor.getString("factorType");
                 factorType = getFactorDescription(factorType, factor);
-                System.out.println("[ " + (i + 1) + " ] : " + factorType);
+                System.err.println("[ " + (i + 1) + " ] : " + factorType);
             }
         }
 
@@ -200,13 +200,13 @@ public class OktaMFA {
         String answer = "";
 
         // Prompt the user for the Security Question Answer
-        System.out.println("\nSecurity Question Factor Authentication\nEnter 'change factor' to use a different factor\n");
+        System.err.println("\nSecurity Question Factor Authentication\nEnter 'change factor' to use a different factor\n");
         while ("".equals(sessionToken)) {
             if (!"".equals(answer)) {
-                System.out.println("Incorrect answer, please try again");
+                System.err.println("Incorrect answer, please try again");
             }
-            System.out.println(question);
-            System.out.println("Answer: ");
+            System.err.println(question);
+            System.err.println("Answer: ");
             answer = scanner.nextLine();
 
             // Factor change requested
@@ -235,23 +235,23 @@ public class OktaMFA {
         String answer = "";
         String sessionToken = "";
 
-        System.out.println("\nSMS Factor Authentication \nEnter 'change factor' to use a different factor");
+        System.err.println("\nSMS Factor Authentication \nEnter 'change factor' to use a different factor");
         while ("".equals(sessionToken)) {
             if (!"".equals(answer)) {
-                System.out.println("Incorrect passcode, please try again or type 'new code' to be sent a new SMS passcode");
+                System.err.println("Incorrect passcode, please try again or type 'new code' to be sent a new SMS passcode");
             } else {
                 // Send initial code to the user
                 verifyAnswer("", factor, stateToken, "sms");
             }
 
-            System.out.println("SMS Code: ");
+            System.err.println("SMS Code: ");
             answer = scanner.nextLine();
 
             switch (answer.toLowerCase()) {
                 case "new code":
                     // New SMS passcode requested
                     answer = "";
-                    System.out.println("New code sent! \n");
+                    System.err.println("New code sent! \n");
                     break;
                 case "change factor":
                     // Factor change requested
@@ -279,13 +279,13 @@ public class OktaMFA {
         String answer = "";
 
         // Prompt for token
-        System.out.println("\n" + factor.getString("provider") + " Token Factor Authentication\nEnter 'change factor' to use a different factor");
+        System.err.println("\n" + factor.getString("provider") + " Token Factor Authentication\nEnter 'change factor' to use a different factor");
         while ("".equals(sessionToken)) {
             if (!"".equals(answer)) {
-                System.out.println("Invalid token, please try again");
+                System.err.println("Invalid token, please try again");
             }
 
-            System.out.println("Token: ");
+            System.err.println("Token: ");
             answer = scanner.nextLine();
 
             // Factor change requested
@@ -311,16 +311,16 @@ public class OktaMFA {
      */
     private static String pushFactor(JSONObject factor, String stateToken) throws JSONException, IOException {
         String sessionToken = "";
-        System.out.println("\nPush Factor Authentication");
+        System.err.println("\nPush Factor Authentication");
 
         while ("".equals(sessionToken)) {
             // Verify if Okta Push has been verified
             sessionToken = verifyAnswer(null, factor, stateToken, "push");
-            System.out.println(sessionToken);
+            System.err.println(sessionToken);
 
             // Session has timed out
             if (sessionToken.equals("Timeout")) {
-                System.out.println("Session has timed out");
+                System.err.println("Session has timed out");
                 return "timeout";
             }
         }
@@ -371,8 +371,8 @@ public class OktaMFA {
         // An error has been returned by Okta
         if (jsonObjResponse.has("errorCode")) {
             String errorSummary = jsonObjResponse.getString("errorSummary");
-            System.out.println(errorSummary);
-            System.out.println("Please try again");
+            System.err.println(errorSummary);
+            System.err.println("Please try again");
 
             if (factorType.equals("question")) {
                 questionFactor(factor, stateToken);
@@ -434,7 +434,7 @@ public class OktaMFA {
                         pushResult = jsonTransaction.getString("status");
                     }
 
-                    System.out.println("Waiting for you to approve the Okta push notification on your device...");
+                    System.err.println("Waiting for you to approve the Okta push notification on your device...");
                     try {
                         Thread.sleep(500);
                     } catch (InterruptedException iex) {

--- a/src/main/java/com/okta/tools/helpers/MenuHelper.java
+++ b/src/main/java/com/okta/tools/helpers/MenuHelper.java
@@ -23,7 +23,7 @@ public class MenuHelper {
         int selection = -1;
         while (selection == -1) {
             //prompt user for selection
-            System.out.print("Selection: ");
+            System.err.print("Selection: ");
             String selectInput = scanner.nextLine();
             try {
                 selection = Integer.parseInt(selectInput) - 1;

--- a/src/main/java/com/okta/tools/helpers/RoleHelper.java
+++ b/src/main/java/com/okta/tools/helpers/RoleHelper.java
@@ -52,16 +52,16 @@ public class RoleHelper {
         } else if (roleIdpPairs.size() > 1) {
             List<AccountOption> accountOptions = getAvailableRoles(samlResponse);
 
-            System.out.println("\nPlease choose the role you would like to assume: ");
+            System.err.println("\nPlease choose the role you would like to assume: ");
             //Gather list of applicable AWS roles
             int i = 0;
             int j = -1;
 
             for (AccountOption accountOption : accountOptions) {
-                System.out.println(accountOption.accountName);
+                System.err.println(accountOption.accountName);
                 for (RoleOption roleOption : accountOption.roleOptions) {
                     roleArns.add(roleOption.roleArn);
-                    System.out.println("\t[ " + (i + 1) + " ]: " + roleOption.roleName);
+                    System.err.println("\t[ " + (i + 1) + " ]: " + roleOption.roleName);
                     if (roleOption.roleArn.equals(environment.awsRoleToAssume)) {
                         j = i;
                     }
@@ -69,7 +69,7 @@ public class RoleHelper {
                 }
             }
             if ((environment.awsRoleToAssume != null && !environment.awsRoleToAssume.isEmpty()) && j == -1) {
-                System.out.println("No match for role " + environment.awsRoleToAssume);
+                System.err.println("No match for role " + environment.awsRoleToAssume);
             }
 
             // Default to no selection
@@ -78,7 +78,7 @@ public class RoleHelper {
             // If config.properties has matching role, use it and don't prompt user to select
             if (j >= 0) {
                 selection = j;
-                System.out.println("Selected option " + (j + 1) + " based on OKTA_AWS_ROLE_TO_ASSUME value");
+                System.err.println("Selected option " + (j + 1) + " based on OKTA_AWS_ROLE_TO_ASSUME value");
             } else {
                 //Prompt user for role selection
                 selection = MenuHelper.promptForMenuSelection(roleArns.size());
@@ -88,7 +88,7 @@ public class RoleHelper {
             principalArn = roleIdpPairs.get(roleArn);
         } else {
             Map.Entry<String, String> role = roleIdpPairs.entrySet().iterator().next();
-            System.out.println("Auto select role as only one is available : " + role.getKey());
+            System.err.println("Auto select role as only one is available : " + role.getKey());
             roleArn = role.getKey();
             principalArn = role.getValue();
         }


### PR DESCRIPTION
Problem Statement
-----------------
Issue #59 states:
> This was talked about in the recent [AWS CLI talk at re:Invent ](http://awsfeed.com/post/168047446129/aws-reinvent-2017-aws-cli-2017-and-beyond)
> 
> By supporting returning a specific JSON object, as described here: http://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes [okta-aws-cli-assume-role](https://github.com/oktadeveloper/okta-aws-cli-assume-role) can integrate better with the [aws-cli](https://aws.amazon.com/cli/) command.
> 
> See example here: https://github.com/awslabs/awsprocesscreds
> 
> /cc: @AlainODea @mraible @rdegges @joelfranusic-okta

Solution
--------
 - Add CredentialProcess entry-point

 - Move logging/console interaction to STDERR (allow 2>/dev/null)

 - Depends on #201 unless you only have one AWS role assigned in Okta

Resolves #59
