### PR TITLE
:bug: Download latest released jar file to install

### DIFF
--- a/bin/Install-OktaAwsCli.ps1
+++ b/bin/Install-OktaAwsCli.ps1
@@ -31,8 +31,10 @@ function Install-OktaAwsCli {
     New-Item -ItemType File -Path $HOME\.okta\uptodate | Out-Null
     # .NET apparently doesn't default to TLS 1.2 and GitHub requires it
     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+    $LatestReleaseResponse = Invoke-RestMethod -Uri "https://api.github.com/repos/oktadeveloper/okta-aws-cli-assume-role/releases/latest"
+    $Asset = $LatestReleaseResponse.assets | Where-Object { $_.content_type -eq "application/java-archive" }
     $Client = New-Object System.Net.WebClient
-    $Client.DownloadFile("https://github.com/oktadeveloper/okta-aws-cli-assume-role/releases/download/v1.0.2/okta-aws-cli-1.0.2.jar", "$Home\.okta\okta-aws-cli.jar")
+    $Client.DownloadFile($Asset.browser_download_url, "$Home\.okta\okta-aws-cli.jar")
     Add-Content -Path $Home/.okta/config.properties -Value "
 #OktaAWSCLI
 OKTA_ORG=acmecorp.okta.com.changeme.local


### PR DESCRIPTION
Problem Statement
-----------------
The PowerShell install script also faces the same problem described in #187.


Solution
--------
The url of the latest released jar is obtained from the [get-latest-release github api](https://developer.github.com/v3/repos/releases/#get-the-latest-release) and the url is used to download the file.

