### PR TITLE
:bug: Profile names break AWS Java SDK 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,12 @@
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.22.0</version>
+            <scope>test</scope>
+        </dependency>
         <!-- To avoid compiler warnings about @API annotations in JUnit code -->
         <dependency>
             <groupId>org.apiguardian</groupId>

--- a/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
+++ b/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
@@ -125,7 +125,7 @@ final class OktaAwsCliAssumeRole {
         Instant sessionExpiry = startInstant.plus(assumeRequest.getDurationSeconds() - 30, ChronoUnit.SECONDS);
         AssumeRoleWithSAMLResult assumeResult = roleHelper.assumeChosenAwsRole(assumeRequest);
 
-        String profileName = profileHelper.getProfileName(assumeResult, environment.oktaProfile);
+        String profileName = profileHelper.getProfileName(assumeResult);
         if (!environment.oktaEnvMode) {
             profileHelper.createAwsProfile(assumeResult, profileName);
             updateConfig(assumeRequest, sessionExpiry, profileName);

--- a/src/main/java/com/okta/tools/helpers/CredentialsHelper.java
+++ b/src/main/java/com/okta/tools/helpers/CredentialsHelper.java
@@ -5,7 +5,7 @@ import com.okta.tools.aws.settings.Credentials;
 
 import java.io.IOException;
 
-public final class CredentialsHelper {
+public class CredentialsHelper {
 
     private final OktaAwsCliEnvironment environment;
 

--- a/src/main/java/com/okta/tools/helpers/ProfileHelper.java
+++ b/src/main/java/com/okta/tools/helpers/ProfileHelper.java
@@ -36,19 +36,16 @@ public class ProfileHelper {
     }
 
     public String getProfileName(AssumeRoleWithSAMLResult assumeResult) {
-        String credentialsProfileName;
         if (StringUtils.isNotBlank(environment.oktaProfile)) {
-            credentialsProfileName = environment.oktaProfile;
-        } else {
-            credentialsProfileName = assumeResult.getAssumedRoleUser().getArn();
-            Matcher matcher = assumedRoleUserPattern.matcher(credentialsProfileName);
-            if (matcher.matches()) {
-                credentialsProfileName = matcher.group("roleName") + "_" + matcher.group("account");
-            } else {
-                credentialsProfileName = "temp";
-            }
+            return environment.oktaProfile;
         }
 
-        return credentialsProfileName;
+        String credentialsProfileName = assumeResult.getAssumedRoleUser().getArn();
+        Matcher matcher = assumedRoleUserPattern.matcher(credentialsProfileName);
+        if (matcher.matches()) {
+            return matcher.group("roleName") + "_" + matcher.group("account");
+        }
+
+        return "temp";
     }
 }

--- a/src/test/java/com/okta/tools/helpers/ProfileHelperTest.java
+++ b/src/test/java/com/okta/tools/helpers/ProfileHelperTest.java
@@ -1,0 +1,79 @@
+package com.okta.tools.helpers;
+
+import com.amazonaws.services.securitytoken.model.AssumeRoleWithSAMLResult;
+import com.amazonaws.services.securitytoken.model.AssumedRoleUser;
+import com.amazonaws.services.securitytoken.model.Credentials;
+import com.okta.tools.OktaAwsCliEnvironment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class ProfileHelperTest {
+
+    private static final String fakeAccessKey = "Fake-access-key";
+    private static final String fakeSecretKey = "Fake-secret-key";
+    private static final String fakeSessionToken = "Fake-session-token";
+    private static final String fakeCredentialsProfileName = "arn:aws:sts::123456789012:assumed-role/FakeRole/fakey.mcfakerson@fake.example.com";
+    private static final String fakeAssumeRoleUserArn = "arn:aws:sts::123456789012:assumed-role/FakeRole/fakey.mcfakerson@fake.example.com";
+    private static final String expectedGeneratedProfileName = "FakeRole_123456789012";
+    private static final Date fakeExpiryDate = Date.from(Instant.EPOCH);
+    private static final String specifiedOktaProfile = "test";
+    private static final String tempProfileNameFallback = "temp";
+
+    private ProfileHelper profileHelper;
+    private CredentialsHelper credentialsHelper;
+    private AssumeRoleWithSAMLResult assumeRoleWithSAMLResult;
+    private OktaAwsCliEnvironment environment;
+
+    @BeforeEach
+    void setUp() {
+        credentialsHelper = mock(CredentialsHelper.class);
+        environment = new OktaAwsCliEnvironment();
+        profileHelper = new ProfileHelper(credentialsHelper, environment);
+        assumeRoleWithSAMLResult = new AssumeRoleWithSAMLResult();
+        Credentials credentials = new Credentials(fakeAccessKey, fakeSecretKey, fakeSessionToken, fakeExpiryDate);
+        assumeRoleWithSAMLResult.setCredentials(credentials);
+        AssumedRoleUser assumedRoleUser = new AssumedRoleUser();
+        assumedRoleUser.setArn(fakeAssumeRoleUserArn);
+        assumeRoleWithSAMLResult.setAssumedRoleUser(assumedRoleUser);
+    }
+
+    @Test
+    void createAwsProfile() throws IOException {
+        profileHelper.createAwsProfile(assumeRoleWithSAMLResult, fakeCredentialsProfileName);
+
+        verify(credentialsHelper).updateCredentialsFile(fakeCredentialsProfileName, fakeAccessKey, fakeSecretKey, fakeSessionToken);
+    }
+
+    @Test
+    void getProfileName() {
+        String profileName = profileHelper.getProfileName(assumeRoleWithSAMLResult);
+
+        assertEquals(expectedGeneratedProfileName, profileName);
+    }
+
+    @Test
+    void getProfileNameWithSpecifiedOktaProfile() {
+        environment.oktaProfile = specifiedOktaProfile;
+
+        String profileName = profileHelper.getProfileName(assumeRoleWithSAMLResult);
+
+        assertEquals(specifiedOktaProfile, profileName);
+    }
+
+    @Test
+    void getProfileNameWithBrokenAssumedUserArnUsesTemp() {
+        assumeRoleWithSAMLResult.getAssumedRoleUser().setArn("brokenARN");
+
+        String profileName = profileHelper.getProfileName(assumeRoleWithSAMLResult);
+
+        assertEquals(tempProfileNameFallback, profileName);
+    }
+}


### PR DESCRIPTION
Problem Statement
-----------------
Issue #208 states:
> please see discussion here: [aws/aws-sdk-java-v2#389 (comment)](https://github.com/aws/aws-sdk-java-v2/issues/389#issuecomment-421195380)

Solution
--------
 - Use roleName_account as generated role name (fallback to "temp")

Resolves #208