### PR TITLE
:bug: NPE on second TOTP attempt

### DIFF
--- a/src/main/java/com/okta/tools/authentication/OktaMFA.java
+++ b/src/main/java/com/okta/tools/authentication/OktaMFA.java
@@ -379,7 +379,7 @@ public class OktaMFA {
             }
 
             if (factorType.equals("token:software:totp")) {
-                totpFactor(factor, stateToken);
+                sessionToken = totpFactor(factor, stateToken);
             }
         }
 


### PR DESCRIPTION
Problem Statement
-----------------
Issue #215 states:
> **Describe the bug**
> 
> When token verification fails the `java.lang.NullPointerException` error shows up after entering token again.
> 
> _Example 1:_
> 
> ```
> Username: ***@***.com
> 
> GOOGLE Token Factor Authentication
> Enter 'change factor' to use a different factor
> Token:
> 111111
> Invalid Passcode/Answer
> Please try again
> 
> GOOGLE Token Factor Authentication
> Enter 'change factor' to use a different factor
> Token:
> 932072
> Exception in thread "main" java.lang.NullPointerException
> 	at com.okta.tools.authentication.OktaMFA.handleTimeoutsAndChanges(OktaMFA.java:77)
> 	at com.okta.tools.authentication.OktaMFA.promptForFactor(OktaMFA.java:54)
> 	at com.okta.tools.authentication.OktaAuthentication.getOktaSessionToken(OktaAuthentication.java:38)
> 	at com.okta.tools.saml.OktaSaml.getSamlResponse(OktaSaml.java:44)
> 	at com.okta.tools.OktaAwsCliAssumeRole.run(OktaAwsCliAssumeRole.java:88)
> 	at com.okta.tools.awscli.main(awscli.java:33)
> ```
> 
> _Example 2:_
> 
> ```
> Username: ***@***.com
> 
> GOOGLE Token Factor Authentication
> Enter 'change factor' to use a different factor
> Token:
> 692106
> Each code can only be used once. Please wait for a new code and try again.
> Please try again
> 
> GOOGLE Token Factor Authentication
> Enter 'change factor' to use a different factor
> Token:
> 387212
> Exception in thread "main" java.lang.NullPointerException
> 	at com.okta.tools.authentication.OktaMFA.handleTimeoutsAndChanges(OktaMFA.java:77)
> 	at com.okta.tools.authentication.OktaMFA.promptForFactor(OktaMFA.java:54)
> 	at com.okta.tools.authentication.OktaAuthentication.getOktaSessionToken(OktaAuthentication.java:38)
> 	at com.okta.tools.saml.OktaSaml.getSamlResponse(OktaSaml.java:44)
> 	at com.okta.tools.OktaAwsCliAssumeRole.run(OktaAwsCliAssumeRole.java:88)
> 	at com.okta.tools.awscli.main(awscli.java:33)
> ```
> 
> **To Reproduce**
> Steps to reproduce the behavior:
> 
>     1. Enter wrong token
> 
>     2. Enter proper token
> 
>     3. See error
> 
> 
> **Expected behavior**
> Verification pass after second try, error shouldn't show up.
> 
> **Additional context**
> Version: 1.0.2

Solution
--------
 - Propagate sessionToken from recursive TOTP check

Aside: recursion in MFA verification makes the code unnecessarily
complex and error-prone. It should be removed.

Resolves #215

