### PR TITLE
:seedling: Machine-consumable role list

### DIFF
--- a/bin/Install-OktaAwsCli.ps1
+++ b/bin/Install-OktaAwsCli.ps1
@@ -69,6 +69,18 @@ function With-Okta {
         $env:OKTA_PROFILE = $OriginalOKTA_PROFILE
     }
 }
+function Okta-ListRoles {
+    $InternetOptions = Get-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings"
+    if ($InternetOptions.ProxyServer) {
+        ($ProxyHost, $ProxyPort) = $InternetOptions.ProxyServer.Split(":")
+    }
+    if ($InternetOptions.ProxyOverride) {
+        $NonProxyHosts = [System.String]::Join("|", ($InternetOptions.ProxyOverride.Replace("<local>", "").Split(";") | Where-Object {$_}))
+    } else {
+        $NonProxyHosts = ""
+    }
+    java "-Dhttp.proxyHost=$ProxyHost" "-Dhttp.proxyPort=$ProxyPort" "-Dhttps.proxyHost=$ProxyHost" "-Dhttps.proxyPort=$ProxyPort" "-Dhttp.nonProxyHosts=$NonProxyHosts" -classpath $HOME\.okta\* com.okta.tools.ListRoles
+}
 function okta-aws {
     Param([string]$Profile)
     With-Okta -Profile $Profile aws --profile $Profile @args

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -92,6 +92,12 @@ env OKTA_PROFILE=$profile java -classpath ~/.okta/okta-aws-cli.jar com.okta.tool
 ' > "$PREFIX/bin/withokta"
 chmod +x "$PREFIX/bin/withokta"
 
+# Create okta-listroles command
+echo '#!/bin/bash
+java -classpath ~/.okta/okta-aws-cli.jar com.okta.tools.ListRoles
+' > "$PREFIX/bin/okta-listroles"
+chmod +x "$PREFIX/bin/okta-listroles"
+
 # Configure Okta AWS CLI
 oktaConfig="${HOME}/.okta/config.properties"
 grep '^#OktaAWSCLI' "${oktaConfig}" > /dev/null 2>&1

--- a/bin/okta-listroles
+++ b/bin/okta-listroles
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Copyright 2018 Okta
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+java -classpath ~/.okta/okta-aws-cli.jar com.okta.tools.ListRoles

--- a/src/main/java/com/okta/tools/ListRoles.java
+++ b/src/main/java/com/okta/tools/ListRoles.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Okta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.tools;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.okta.tools.helpers.CookieHelper;
+import com.okta.tools.helpers.RoleHelper;
+import com.okta.tools.models.AccountOption;
+import com.okta.tools.saml.OktaSaml;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ListRoles {
+    public static void main(String[] args) throws Exception {
+        OktaAwsCliEnvironment environment = OktaAwsConfig.loadEnvironment();
+        CookieHelper cookieHelper = new CookieHelper(environment);
+        OktaSaml oktaSaml = new OktaSaml(environment, cookieHelper);
+        String samlResponse = oktaSaml.getSamlResponse();
+        RoleHelper roleHelper = new RoleHelper(environment);
+        List<AccountOption> availableRoles = roleHelper.getAvailableRoles(samlResponse);
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.writeValue(System.out, availableRoles);
+    }
+}

--- a/src/main/java/com/okta/tools/helpers/RoleHelper.java
+++ b/src/main/java/com/okta/tools/helpers/RoleHelper.java
@@ -102,7 +102,7 @@ public class RoleHelper {
                 .withDurationSeconds(stsDuration);
     }
 
-    private List<AccountOption> getAvailableRoles(String samlResponse) throws IOException {
+    public List<AccountOption> getAvailableRoles(String samlResponse) throws IOException {
         Document document = AwsSamlRoleUtils.getSigninPageDocument(samlResponse);
         return AwsSamlSigninParser.parseAccountOptions(document);
     }


### PR DESCRIPTION
Problem Statement
-----------------
Issue #223 states:
> **Describe the bug**
> 
> Given a user who has multiple roles in a given AWS account, how can I:
> 
>     1. Retrieve the list of possible roles on behalf of the user so that I can do something programmatic with them?
> 
>     2. Get credentials for a different role on that account while the credentials for the first role are active?
> 
> 
> I'm presuming that if I knew which role they wanted to assume, I could set the OKTA_PROFILE to be some combination of the account name/id and the role (which is what the code does by default). This would solve #2. But, without knowing which roles are assumable by the user, I cannot set the profile name to something that would trigger the second credentials because just running `withokta` with the same profile and a blank OKTA_AWS_ROLE_TO_ASSUME results a "Yes, you have active credentials for a role in that account."
> 
> Normally, this is exactly what I want. But, I want to be able to trigger the generation of a second set of credentials if needed.

Solution
--------
 - Allow output of assumable account+role list as JSON

 - Add entry point main class com.okta.tools.ListRoles

 - Add okta-listroles bash script

 - Add Okta-ListRoles PowerShell function

Resolves #223 (definitely incompletely, but it should help)