### PR TITLE
Add ability to pass in OKTA_AWS_REGION and use it for other regions for STS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,7 @@ dependency-reduced-pom.xml
 .idea
 *.iml
 move.bat
+.factorypath
+.vscode
 
 out/oktaawscli.jar

--- a/Readme.MD
+++ b/Readme.MD
@@ -135,6 +135,7 @@ Here is the list of parameters that can be environment variables or settings in 
   - ```OKTA_BROWSER_AUTH``` set to **true** to use integrated web browser for authentication (default: **false**)
   - ```OKTA_COOKIES_PATH``` is directory path to store cookies.properties for Okta. This is particularly useful when running this tool in many concurrent processes like you might with **OKTA_ENV_MODE** (default: ~/.okta)
   - ```OKTA_PROFILE``` is the name of the AWS profile to create/reuse.  May also be specified on the commandline by ```--profile```. (default: get AWS profile name based on per-session STS user name)  
+  - ```OKTA_AWS_REGION``` is the default AWS region to store with the created profile.
   - ```OKTA_AWS_ROLE_TO_ASSUME``` is the role to use. If present will try to match okta account's retrieved role list and use it. Will still prompt if no match found.
   - ```OKTA_STS_DURATION``` is the duration the role will be assumed, in seconds. The maximum session duration allowed by AWS is 12 hours and this needs to be set on the role as well.  Defaults to 1hr.
   

--- a/src/main/java/com/okta/tools/OktaAwsCliEnvironment.java
+++ b/src/main/java/com/okta/tools/OktaAwsCliEnvironment.java
@@ -15,17 +15,18 @@ public class OktaAwsCliEnvironment {
     public String awsRoleToAssume;
 
     public int stsDuration;
+    public final String awsRegion;
     public final boolean oktaEnvMode;
 
     public OktaAwsCliEnvironment()
     {
-        this(false, null, null, null, null, null, null, null, 0, false);
+        this(false, null, null, null, null, null, null, null, 0, null, false);
     }
 
     public OktaAwsCliEnvironment(boolean browserAuth, String oktaOrg,
                                  String oktaUsername, Supplier<String> oktaPassword, String oktaCookiesPath,
                                  String oktaProfile, String oktaAwsAppUrl, String awsRoleToAssume,
-                                 int stsDuration,
+                                 int stsDuration, String awsRegion,
                                  boolean oktaEnvMode) {
         this.browserAuth = browserAuth;
         this.oktaOrg = oktaOrg;
@@ -36,6 +37,7 @@ public class OktaAwsCliEnvironment {
         this.oktaAwsAppUrl = oktaAwsAppUrl;
         this.awsRoleToAssume = awsRoleToAssume;
         this.stsDuration = stsDuration;
+        this.awsRegion = awsRegion;
         this.oktaEnvMode = oktaEnvMode;
     }
 }

--- a/src/main/java/com/okta/tools/OktaAwsConfig.java
+++ b/src/main/java/com/okta/tools/OktaAwsConfig.java
@@ -56,6 +56,7 @@ final class OktaAwsConfig {
                 getEnvOrConfig(properties, "OKTA_AWS_APP_URL"),
                 getEnvOrConfig(properties, "OKTA_AWS_ROLE_TO_ASSUME"),
                 getStsDurationOrDefault(getEnvOrConfig(properties, "OKTA_STS_DURATION")),
+                getAwsRegionOrDefault(getEnvOrConfig(properties, "OKTA_AWS_REGION")),
                 Boolean.parseBoolean(getEnvOrConfig(properties, "OKTA_ENV_MODE"))
         );
     }

--- a/src/main/java/com/okta/tools/aws/settings/Credentials.java
+++ b/src/main/java/com/okta/tools/aws/settings/Credentials.java
@@ -31,6 +31,7 @@ public class Credentials extends Settings {
     static final String ACCES_KEY_ID = "aws_access_key_id";
     static final String SECRET_ACCESS_KEY = "aws_secret_access_key";
     static final String SESSION_TOKEN = "aws_session_token";
+    static final String AWS_DEFAULT_REGION = "region";
 
     /**
      * Create a Credentials object from a given {@link Reader}. The data given by this {@link Reader} should
@@ -49,11 +50,13 @@ public class Credentials extends Settings {
      * @param name            The name of the profile.
      * @param awsAccessKey    The access key to use for the profile.
      * @param awsSecretKey    The secret key to use for the profile.
+     * @param awsRegion       The region to use for the profile.
      * @param awsSessionToken The session token to use for the profile.
      */
-    public void addOrUpdateProfile(String name, String awsAccessKey, String awsSecretKey, String awsSessionToken) {
+    public void addOrUpdateProfile(String name, String awsAccessKey, String awsSecretKey, String awsRegion, String awsSessionToken) {
         setProperty(name, ACCES_KEY_ID, awsAccessKey);
         setProperty(name, SECRET_ACCESS_KEY, awsSecretKey);
+        setProperty(name, AWS_DEFAULT_REGION, awsRegion);
         setProperty(name, SESSION_TOKEN, awsSessionToken);
     }
 }

--- a/src/main/java/com/okta/tools/aws/settings/MultipleProfile.java
+++ b/src/main/java/com/okta/tools/aws/settings/MultipleProfile.java
@@ -25,6 +25,7 @@ public class MultipleProfile extends Settings {
     private static final String SOURCE_PROFILE = "source_profile";
     private static final String PROFILE_EXPIRY = "profile_expiry";
     private static final String OKTA_ROLE_ARN = "okta_roleArn";
+    private static final String AWS_DEFAULT_REGION = "region";
 
     /**
      * Create a Profiles object from a given {@link Reader}. The data given by this {@link Reader} should
@@ -65,11 +66,13 @@ public class MultipleProfile extends Settings {
      *
      * @param name         The name of the profile.
      * @param roleArn      ARN of the role to assume
+     * @param awsRegion    Region to use for assumption
      * @param expiry       expiry time of the profile session.
      */
-    public void addOrUpdateProfile(String name, String roleArn, Instant expiry) {
+    public void addOrUpdateProfile(String name, String roleArn, String awsRegion, Instant expiry) {
         setProperty(name, SOURCE_PROFILE, name);
         setProperty(name, OKTA_ROLE_ARN, roleArn);
+        setProperty(name, AWS_DEFAULT_REGION, awsRegion);
         setProperty(name, PROFILE_EXPIRY, expiry.toString());
     }
 }

--- a/src/main/java/com/okta/tools/helpers/CredentialsHelper.java
+++ b/src/main/java/com/okta/tools/helpers/CredentialsHelper.java
@@ -19,14 +19,15 @@ public class CredentialsHelper {
      * @param profileName     The profile to use
      * @param awsAccessKey    The access key to use
      * @param awsSecretKey    The secret key to use
+     * @param awsregion       The region to use
      * @param awsSessionToken The session token to use
      * @throws IOException    if a file system or permissions error occurs
      */
-    void updateCredentialsFile(String profileName, String awsAccessKey, String awsSecretKey, String awsSessionToken)
+    void updateCredentialsFile(String profileName, String awsAccessKey, String awsSecretKey, String awsRegion, String awsSessionToken)
             throws IOException {
         FileHelper.usingPath(FileHelper.getAwsDirectory().resolve("credentials"), reader -> {
             Credentials credentials = new Credentials(reader);
-            credentials.addOrUpdateProfile(profileName, awsAccessKey, awsSecretKey, awsSessionToken);
+            credentials.addOrUpdateProfile(profileName, awsAccessKey, awsSecretKey, awsRegion, awsSessionToken);
             return credentials;
         }, Credentials::save);
     }

--- a/src/main/java/com/okta/tools/helpers/ProfileHelper.java
+++ b/src/main/java/com/okta/tools/helpers/ProfileHelper.java
@@ -32,7 +32,10 @@ public class ProfileHelper {
         String awsSecretKey = temporaryCredentials.getAWSSecretKey();
         String awsSessionToken = temporaryCredentials.getSessionToken();
 
-        credentialsHelper.updateCredentialsFile(credentialsProfileName, awsAccessKey, awsSecretKey, awsSessionToken);
+        String awsRegion = environment.awsRegion;
+        
+        credentialsHelper.updateCredentialsFile(credentialsProfileName, awsAccessKey, awsSecretKey, awsRegion,
+                awsSessionToken);
     }
 
     public String getProfileName(AssumeRoleWithSAMLResult assumeResult) {

--- a/src/main/java/com/okta/tools/helpers/RoleHelper.java
+++ b/src/main/java/com/okta/tools/helpers/RoleHelper.java
@@ -33,7 +33,7 @@ public class RoleHelper {
         AWSCredentialsProvider nullCredentialsProvider = new AWSStaticCredentialsProvider(nullCredentials);
         AWSSecurityTokenService sts = AWSSecurityTokenServiceClientBuilder
                 .standard()
-                .withRegion(Regions.US_EAST_1)
+                .withRegion(Regions.GovCloud)
                 .withCredentials(nullCredentialsProvider)
                 .build();
         return sts.assumeRoleWithSAML(assumeRequest);

--- a/src/main/java/com/okta/tools/helpers/RoleHelper.java
+++ b/src/main/java/com/okta/tools/helpers/RoleHelper.java
@@ -33,7 +33,7 @@ public class RoleHelper {
         AWSCredentialsProvider nullCredentialsProvider = new AWSStaticCredentialsProvider(nullCredentials);
         AWSSecurityTokenService sts = AWSSecurityTokenServiceClientBuilder
                 .standard()
-                .withRegion(Regions.GovCloud)
+                .withRegion(environment.awsRegion)
                 .withCredentials(nullCredentialsProvider)
                 .build();
         return sts.assumeRoleWithSAML(assumeRequest);

--- a/src/main/java/com/okta/tools/helpers/SessionHelper.java
+++ b/src/main/java/com/okta/tools/helpers/SessionHelper.java
@@ -97,7 +97,7 @@ public final class SessionHelper {
     public void addOrUpdateProfile(Instant sessionExpiry) throws IOException {
         FileHelper.usingPath(FileHelper.getOktaDirectory().resolve("profiles"), reader -> {
             MultipleProfile multipleProfile = new MultipleProfile(reader);
-            multipleProfile.addOrUpdateProfile(environment.oktaProfile, environment.awsRoleToAssume, sessionExpiry);
+            multipleProfile.addOrUpdateProfile(environment.oktaProfile, environment.awsRoleToAssume, environment.awsRegion,sessionExpiry);
             return multipleProfile;
         }, MultipleProfile::save);
     }

--- a/src/test/java/com/okta/tools/aws/settings/CredentialsTest.java
+++ b/src/test/java/com/okta/tools/aws/settings/CredentialsTest.java
@@ -28,15 +28,18 @@ class CredentialsTest {
     private String existingCredentials = "[default]\n"
             + Credentials.ACCES_KEY_ID + " = " + "defaultaccesskey" + "\n"
             + Credentials.SECRET_ACCESS_KEY + " = " + "defaultsecretkey" + "\n"
+            + Credentials.AWS_DEFAULT_REGION + " = " + "defaultregion" + "\n"
             + Credentials.SESSION_TOKEN + " = " + "defaultsessiontoken";
 
     private String roleName = "newrole";
     private String accessKey = "accesskey";
     private String secretKey = "secretkey";
+    private String awsRegion = "region";
     private String sessionToken = "sessiontoken";
     private String manualRole = "[" + roleName + "]\n"
             + Credentials.ACCES_KEY_ID + " = " + accessKey + "\n"
             + Credentials.SECRET_ACCESS_KEY + " = " + secretKey + "\n"
+            + Credentials.AWS_DEFAULT_REGION + " = " + awsRegion + "\n"
             + Credentials.SESSION_TOKEN + " = " + sessionToken;
 
     /*
@@ -48,7 +51,7 @@ class CredentialsTest {
         final StringWriter credentialsWriter = new StringWriter();
         final Credentials credentials = new Credentials(credentialsReader);
 
-        credentials.addOrUpdateProfile(roleName, accessKey, secretKey, sessionToken);
+        credentials.addOrUpdateProfile(roleName, accessKey, secretKey, awsRegion, sessionToken);
         credentials.save(credentialsWriter);
 
         String given = org.apache.commons.lang.StringUtils.remove(credentialsWriter.toString().trim(), '\r');
@@ -65,7 +68,7 @@ class CredentialsTest {
         final StringWriter credentialsWriter = new StringWriter();
         final Credentials credentials = new Credentials(credentialsReader);
 
-        credentials.addOrUpdateProfile(roleName, accessKey, secretKey, sessionToken);
+        credentials.addOrUpdateProfile(roleName, accessKey, secretKey, awsRegion, sessionToken);
         credentials.save(credentialsWriter);
 
         String expected = existingCredentials + "\n\n" + manualRole;
@@ -88,9 +91,10 @@ class CredentialsTest {
                 + "[" + roleName + "]\n"
                 + Credentials.ACCES_KEY_ID + " = " + updatedPrefix + accessKey + "\n"
                 + Credentials.SECRET_ACCESS_KEY + " = " + updatedPrefix + secretKey + "\n"
+                + Credentials.AWS_DEFAULT_REGION + " = " + awsRegion + "\n"
                 + Credentials.SESSION_TOKEN + " = " + updatedPrefix + sessionToken;
 
-        credentials.addOrUpdateProfile(roleName, updatedPrefix + accessKey, updatedPrefix + secretKey, updatedPrefix + sessionToken);
+        credentials.addOrUpdateProfile(roleName, updatedPrefix + accessKey, updatedPrefix + secretKey, awsRegion, updatedPrefix + sessionToken);
         credentials.save(credentialsWriter);
 
         String given = org.apache.commons.lang.StringUtils.remove(credentialsWriter.toString().trim(), '\r');
@@ -112,10 +116,11 @@ class CredentialsTest {
                 "[default]\n"
                 + Credentials.ACCES_KEY_ID + " = " + updatedPrefix + accessKey + "\n"
                 + Credentials.SECRET_ACCESS_KEY + " = " + updatedPrefix + secretKey + "\n"
+                + Credentials.AWS_DEFAULT_REGION + " = " + awsRegion + "\n"
                 + Credentials.SESSION_TOKEN + " = " + updatedPrefix + sessionToken + "\n\n"
                 + manualRole;
 
-        credentials.addOrUpdateProfile("default", updatedPrefix + accessKey, updatedPrefix + secretKey, updatedPrefix + sessionToken);
+        credentials.addOrUpdateProfile("default", updatedPrefix + accessKey, updatedPrefix + secretKey, awsRegion, updatedPrefix + sessionToken);
         credentials.save(credentialsWriter);
 
         String given = org.apache.commons.lang.StringUtils.remove(credentialsWriter.toString().trim(), '\r');

--- a/src/test/java/com/okta/tools/helpers/ProfileHelperTest.java
+++ b/src/test/java/com/okta/tools/helpers/ProfileHelperTest.java
@@ -19,6 +19,7 @@ class ProfileHelperTest {
 
     private static final String fakeAccessKey = "Fake-access-key";
     private static final String fakeSecretKey = "Fake-secret-key";
+    private static final String fakeAwsRegion = "Fake-region";
     private static final String fakeSessionToken = "Fake-session-token";
     private static final String fakeCredentialsProfileName = "arn:aws:sts::123456789012:assumed-role/FakeRole/fakey.mcfakerson@fake.example.com";
     private static final String fakeAssumeRoleUserArn = "arn:aws:sts::123456789012:assumed-role/FakeRole/fakey.mcfakerson@fake.example.com";
@@ -35,7 +36,7 @@ class ProfileHelperTest {
     @BeforeEach
     void setUp() {
         credentialsHelper = mock(CredentialsHelper.class);
-        environment = new OktaAwsCliEnvironment();
+        environment = new OktaAwsCliEnvironment(false, null, null, null, null, null, null, null, 0, fakeAwsRegion, false);
         profileHelper = new ProfileHelper(credentialsHelper, environment);
         assumeRoleWithSAMLResult = new AssumeRoleWithSAMLResult();
         Credentials credentials = new Credentials(fakeAccessKey, fakeSecretKey, fakeSessionToken, fakeExpiryDate);
@@ -49,7 +50,7 @@ class ProfileHelperTest {
     void createAwsProfile() throws IOException {
         profileHelper.createAwsProfile(assumeRoleWithSAMLResult, fakeCredentialsProfileName);
 
-        verify(credentialsHelper).updateCredentialsFile(fakeCredentialsProfileName, fakeAccessKey, fakeSecretKey, fakeSessionToken);
+        verify(credentialsHelper).updateCredentialsFile(fakeCredentialsProfileName, fakeAccessKey, fakeSecretKey, fakeAwsRegion, fakeSessionToken);
     }
 
     @Test


### PR DESCRIPTION
Problem Statement
-----------------
Should resolve: https://github.com/oktadeveloper/okta-aws-cli-assume-role/issues/43


Solution
--------
Revert commit b86dc34 to give us back `OKTA_AWS_REGION`, then refactor how this is passed between environments
