### PR TITLE
:bug: Current session used in OKTA_ENV_MODE

### DIFF
--- a/src/main/java/com/okta/tools/helpers/SessionHelper.java
+++ b/src/main/java/com/okta/tools/helpers/SessionHelper.java
@@ -34,6 +34,7 @@ public final class SessionHelper {
      * @throws IOException if file system or permissions errors are encountered
      */
     public Optional<Session> getCurrentSession() throws IOException {
+        if (environment.oktaEnvMode) return Optional.empty();
         if (Files.exists(getSessionPath())) {
             try (FileReader fileReader = new FileReader(getSessionPath().toFile())) {
                 Properties properties = new Properties();


### PR DESCRIPTION
Problem Statement
-----------------
OKTA_ENV_MODE does not update the current session, but will
(unintentionally) make use of the one that is there. This can lead to
dangerous confusing situations where the program run is run with the
credentials of the current session and not the fresh credentials
obtained for OKTA_ENV_MODE.

Solution
--------
 - Suppress current session if OKTA_ENV_MODE is true