### PR TITLE
:bug: Fish install broken

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -47,23 +47,19 @@ function okta-sls {
 ' >> "${bash_functions}"
 fi
 
-# Conditionally update fish profile
-fishConfig="${HOME}/.config/fish/config.fish"
-mkdir -p $(dirname "${fishConfig}")
-touch "${fishConfig}"
-grep '^#OktaAWSCLI' "${fishConfig}" > /dev/null 2>&1
-if [ $? -ne 0 ]
-then
+# Create fish shell functions
+fishFunctionsDir="${HOME}/.config/fish/functions"
+mkdir -p "${fishFunctionsDir}"
 echo '
-#OktaAWSCLI
 function okta-aws
     withokta "aws --profile $argv[1]" $argv
 end
+' > "${fishFunctionsDir}/okta-aws.fish"
+echo '
 function okta-sls
     withokta "sls --stage $argv[1]" $argv
 end
-' >> "${fishConfig}"
-fi
+' >> "${fishFunctionsDir}/okta-sls.fish"
 
 # Conditionally update bash profile
 bashProfile="${HOME}/.bash_profile"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -56,10 +56,6 @@ if [ $? -ne 0 ]
 then
 echo '
 #OktaAWSCLI
-export PATH="$HOME/bin:$PATH"
-function withokta
-    java -Djava.net.useSystemProxies com.okta.tools.WithOkta $argv
-end
 function okta-aws
     withokta "aws --profile $argv[1]" $argv
 end


### PR DESCRIPTION
Problem Statement
-----------------
Issue #234 states:
> **Describe the bug**
> All I know for sure is that after following the install instructions, I cannot execute `okta-aws`. I've been debugging and I already notice one huge bug, which is that the installer added
> 
> ```
> export PATH="$HOME/bin:$PATH"
> ```
> 
> to my `config.fish`. That syntax is valid in `bash`, but in fish it should probably be
> 
> ```
> set -x PATH $HOME/bin $PATH
> ```
> 
> Furthermore, it didn't even create a `/bin` folder in my `$HOME` directory.
> 
> **To Reproduce**
> Steps to reproduce the behavior:
> 
>     1. Install the fish shell
> 
>     2. Execute
> 
> 
> ```
> curl 'https://raw.githubusercontent.com/oktadeveloper/okta-aws-cli-assume-role/master/bin/install.sh' | bash
> ```
> 
>     1. Check your `config.fish`

Solution
--------
 - Don't use export (it's a Bash thing, not fish)

 - Don't create withokta function (there's a withokta script)

Resolves #234

