### PR TITLE
:seedling: Support app-level MFA

### DIFF
--- a/src/main/java/com/okta/tools/authentication/CookieManager.java
+++ b/src/main/java/com/okta/tools/authentication/CookieManager.java
@@ -1,0 +1,34 @@
+package com.okta.tools.authentication;
+
+import com.okta.tools.helpers.CookieHelper;
+
+import java.io.IOException;
+import java.net.CookieHandler;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Adaptor for {@link com.sun.webkit.network.CookieManager} that stores cookies
+ */
+public final class CookieManager extends CookieHandler {
+    // internal class use is intentional: we need RFC6265 cookies which this OpenJFX class handles
+    private final CookieHandler cookieHandler = new com.sun.webkit.network.CookieManager();
+    private final CookieHelper cookieHelper;
+
+    public CookieManager(CookieHelper cookieHelper) {
+        this.cookieHelper = cookieHelper;
+    }
+
+    @Override
+    public Map<String, List<String>> get(URI uri, Map<String,List<String>> requestHeaders) throws IOException
+    {
+        return cookieHandler.get(uri, requestHeaders);
+    }
+
+    @Override
+    public void put(URI uri, Map<String,List<String>> responseHeaders) throws IOException {
+        cookieHelper.storeCookies(responseHeaders);
+        cookieHandler.put(uri, responseHeaders);
+    }
+}


### PR DESCRIPTION
Problem Statement
-----------------
Issue #25 states:
> We use application level sign on policies to enforce MFA for specific applications, however the cli tool doesn't support this. I saw an closed issue from August due to lack of API support. Has this been added to the API? Is there some other solution to this problem?

Solution
--------
 - Use stored cookies for browser authentication

 - Use browser for subsequent authentications when
   OKTA_BROWSER_AUTH=true

 - Use RFC6265 cookie parsing provided by Apache HTTP Components

 - Provide a CookieHandler that delegates to JFX and saves cookies as
   they are updated by HTTP responses

Resolves #25