### PR TITLE
Prefix should be /usr/local

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -40,7 +40,7 @@ This tool has been verified to work on macOS Sierra, High Sierra, Windows Server
 
 1. Run the following in a Terminal:
     ```bash
-    export PREFIX=/usr/local/bin
+    export PREFIX=/usr/local
     curl 'https://raw.githubusercontent.com/oktadeveloper/okta-aws-cli-assume-role/master/bin/install.sh' | bash
     ```
 2. Customize **~/.okta/config.properties** and set **OKTA_ORG** and **OKTA_AWS_APP_URL** appropriately. For example,


### PR DESCRIPTION
Problem Statement
-----------------
When I was installing on mac it tried to install in /usr/local/bin/bin

Solution
--------
Change Prefix env when installing


```
ignacio.tolstoy in ~/code  $ export PREFIX=/usr/local/bin
ignacio.tolstoy in ~/code  $ curl 'https://raw.githubusercontent.com/oktadeveloper/okta-aws-cli-assume-role/master/bin/install.sh' | bash

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3284  100  3284    0     0   8532      0 --:--:-- --:--:-- --:--:--  8552
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   612    0   612    0     0   1406      0 --:--:-- --:--:-- --:--:--  1410
100 51.9M  100 51.9M    0     0  1952k      0  0:00:27  0:00:27 --:--:-- 2120k
bash: line 84: /usr/local/bin/bin/withokta: No such file or directory
chmod: /usr/local/bin/bin/withokta: No such file or directory
bash: line 93: /usr/local/bin/bin/okta-credential_process: No such file or directory
chmod: /usr/local/bin/bin/okta-credential_process: No such file or directory
bash: line 99: /usr/local/bin/bin/okta-listroles: No such file or directory
chmod: /usr/local/bin/bin/okta-listroles: No such file or directory
ignacio.tolstoy in ~/code  $ export PREFIX=/usr/local
ignacio.tolstoy in ~/code  $ curl 'https://raw.githubusercontent.com/oktadeveloper/okta-aws-cli-assume-role/master/bin/install.sh' | bash

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3284  100  3284    0     0  10132      0 --:--:-- --:--:-- --:--:-- 10135
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   612    0   612    0     0   1051      0 --:--:-- --:--:-- --:--:--  1051
100 51.9M  100 51.9M    0     0  1838k      0  0:00:28  0:00:28 --:--:-- 2099k
ignacio.tolstoy in ~/code  $ ls /usr/local
Caskroom/  Frameworks/  aws/  etc/  hg/       lib/  packager/       sbin/   var/
Cellar/    Homebrew/    bin/  git/  include/  opt/  remotedesktop/  share/
ignacio.tolstoy in ~/code  $ ls /usr/local/bin/okta-*
/usr/local/bin/okta-credential_process*  /usr/local/bin/okta-listroles*
```
