### PR TITLE
:bug: AWS command filename isn't always "aws"

### DIFF
--- a/bin/Install-OktaAwsCli.ps1
+++ b/bin/Install-OktaAwsCli.ps1
@@ -82,7 +82,7 @@ function Okta-ListRoles {
 }
 function okta-aws {
     Param([string]$Profile)
-    With-Okta -Profile $Profile aws --profile $Profile @args
+    With-Okta -Profile $Profile ((Get-Command aws).Name) --profile $Profile @args
 }
 function okta-sls {
     Param([string]$Profile)


### PR DESCRIPTION
Problem Statement
-----------------
A comment on issue #85 states:
> @AlainODea FYI, the documentation hasn't been updated yet.
> 
> I had this issue today (this is why I am here!); I had installed the AWS CLI tools via the MSI installer, which creates an `aws.cmd` batch file which itself calls into the Python 3.6 interpreter the MSI installer installs in `C:\Program Files\Amazon\AWSCLI\runtime\`.
> 
> I then ran the command to install okta-aws-cli-assume-role using `Install-OktaAwsCli.ps1`, and received the IOException upon verifying my setup.
> 
> The fix, as was suggested here, was to update the powershell $profile to change `aws` to `aws.cmd`.
> 
> Can this issue be fixed in `Install-OktaAwsCli.ps1` by checking the output of `Get-Command aws.cmd`, and - if a result is returned - updating the powershell profile template accordingly?

Solution
--------
 - Use Get-Command to get the real filename of the aws command

Resolves #85

