### PR TITLE
:bug: SOCKS proxy won't work on Windows

### DIFF
--- a/bin/Install-OktaAwsCli.ps1
+++ b/bin/Install-OktaAwsCli.ps1
@@ -55,7 +55,6 @@ function With-Okta {
         $env:OKTA_PROFILE = $Profile
         $InternetOptions = Get-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings"
         if ($InternetOptions.ProxyEnable) {
-            $InternetOptions = Get-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings"
             $ProxyStrings = $InternetOptions.ProxyServer.Split(";")
             $Proxies = @{}
             ForEach ($ProxyString in $ProxyStrings) {
@@ -74,7 +73,6 @@ function With-Okta {
             } elseif ($Proxies.http) {
                 ($ProxyHost, $ProxyPort) = $Proxies.http
             }
-            ($ProxyHost, $ProxyPort)
             if ($InternetOptions.ProxyOverride) {
                 $NonProxyHosts = [System.String]::Join("|", ($InternetOptions.ProxyOverride.Replace("<local>", "").Split(";") | Where-Object {$_}))
             } else {


### PR DESCRIPTION
Problem Statement
-----------------
Issue #244 states:
> **Describe the bug**
> Exception in thread "main" java.net.UnknownHostException: socks=localhost
> 
> **To Reproduce**
> Steps to reproduce the behavior:
> 
>     1. windows
> 
>     2. manually configure a localhost socks proxy in internet options, notice that browser uses proxy (edge/chrome, not ff) (ssh "dynamic" socks is common)
> 
>     3. disable the proxy, notice that browser does not use proxy
> 
>     4. notice that okta-aws-cli-assume-role tries to use the proxy
> 
> 
> **Expected behavior**
> respects proxy setting like browser.
> 
> **Additional context**
> I think the registry HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Internet Settings\ProxyEnable should be checked. As well the value of HKCU...\ProxyServer can be "socks=hostname:port".

Solution
--------
 - Separate protocol from proxy host when registry provides it

 - Do not configure a proxy if it has been configured, but disabled

Resolves #244

