### PR TITLE
Get credentials for programmatically created OktaAwsCliEnvironment

### DIFF
--- a/src/main/java/com/okta/tools/AWSCredentialsUtil.java
+++ b/src/main/java/com/okta/tools/AWSCredentialsUtil.java
@@ -18,6 +18,7 @@ package com.okta.tools;
 import java.time.Instant;
 
 import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSSessionCredentials;
 import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.services.securitytoken.model.AssumeRoleWithSAMLResult;
 import com.amazonaws.services.securitytoken.model.Credentials;
@@ -29,6 +30,14 @@ public interface AWSCredentialsUtil {
 
         Credentials credentials = samlResult.getCredentials();
 
+        return new BasicSessionCredentials(credentials.getAccessKeyId(), credentials.getSecretAccessKey(), credentials.getSessionToken());
+    }
+    
+    static AWSSessionCredentials getAWSCredential (OktaAwsCliEnvironment environment) throws Exception {
+        AssumeRoleWithSAMLResult samlResult = OktaAwsCliAssumeRole.withEnvironment(environment).getAssumeRoleWithSAMLResult(Instant.now());
+        
+        Credentials credentials = samlResult.getCredentials();
+        
         return new BasicSessionCredentials(credentials.getAccessKeyId(), credentials.getSecretAccessKey(), credentials.getSessionToken());
     }
 

--- a/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
+++ b/src/main/java/com/okta/tools/OktaAwsCliAssumeRole.java
@@ -109,7 +109,7 @@ final class OktaAwsCliAssumeRole {
     AssumeRoleWithSAMLResult getAssumeRoleWithSAMLResult(Instant startInstant) throws Exception {
         init();
 
-        environment.awsRoleToAssume = currentProfile.map(profile1 -> profile1.roleArn).orElse(null);
+        environment.awsRoleToAssume = currentProfile.map(profile1 -> profile1.roleArn).orElse(environment.awsRoleToAssume);
 
         ProfileSAMLResult profileSAMLResult = doRequest(startInstant);
 


### PR DESCRIPTION
Problem Statement
-----------------
Cannot get credentials for a programmatically created OktaAwsCliEnvironment
and although the role is given by the OktaAwsCliEnvironment the user is prompted for selecting the role

Solution
--------
New method `AWSSessionCredentials getAWSCredential (OktaAwsCliEnvironment environment)` in `AWSCredentialsUtil` and using the role provided by `OktaAwsCliEnvironment` by `OktaAwsCliAssumeRole.getAssumeRoleWithSAMLResult(Instant)`


