### PR TITLE
:bug: Crash encountered if password has expired

### DIFF
--- a/src/main/java/com/okta/tools/authentication/OktaAuthentication.java
+++ b/src/main/java/com/okta/tools/authentication/OktaAuthentication.java
@@ -219,12 +219,12 @@ public final class OktaAuthentication {
         }
     }
 
-    private RuntimeException makeException(JSONObject primaryAuthResult, String template, Object... args) {
+    static RuntimeException makeException(JSONObject primaryAuthResult, String template, Object... args) {
         return makeException(primaryAuthResult, null, template, args);
     }
 
     // Create an exception by formatting a string with arguments and appending the json message.
-    private RuntimeException makeException(JSONObject primaryAuthResult, Exception e, String template, Object... args) {
+    static RuntimeException makeException(JSONObject primaryAuthResult, Exception e, String template, Object... args) {
         Object[] argsWithMessageJson =
             Stream.concat(Stream.of(args), Stream.of(primaryAuthResult.toString(2))).toArray();
         String message = String.format(template + "\n\nMessage:\n%s\n", argsWithMessageJson);


### PR DESCRIPTION
Problem Statement
-----------------
Issue #249 states:
> **Describe the bug**
> If a password has expired, the CLI crashes with a vague null pointer exception after the username, password, and MFA token have already been accepted.
> 
> **To Reproduce**
> Steps to reproduce the behavior:
> 
>     1. Ensure your password has expired
> 
>     2. Run `awscli sts get-caller-identity`
> 
>     3. Input your Username, Password, and Token
> 
>     4. See error
> 
> 
> **Expected behavior**
> Some form of description along with the stack trace that indicates the password has expired, perhaps similar to how #101 includes the `java.lang.RuntimeException: You do not have access to AWS through Okta.` bit.
> 
> **Additional context**
> 
> ```
> [matt@matt-dev ~]$ awscli sts get-caller-identity
> Username: username@email.com
> Password:
> 
> GOOGLE Token Factor Authentication
> Enter 'change factor' to use a different factor
> Token:
> xxxxxx
> Exception in thread "main" java.lang.NullPointerException
>         at com.okta.tools.authentication.OktaMFA.handleTimeoutsAndChanges(OktaMFA.java:92)
>         at com.okta.tools.authentication.OktaMFA.promptForFactor(OktaMFA.java:69)
>         at com.okta.tools.authentication.OktaAuthentication.getOktaSessionToken(OktaAuthentication.java:90)
>         at com.okta.tools.saml.OktaSaml.getSamlResponse(OktaSaml.java:58)
>         at com.okta.tools.OktaAwsCliAssumeRole.doRequest(OktaAwsCliAssumeRole.java:120)
>         at com.okta.tools.OktaAwsCliAssumeRole.run(OktaAwsCliAssumeRole.java:90)
>         at com.okta.tools.awscli.main(awscli.java:41)
> ```
> 
> Ran against release okta-aws-cli-1.0.6.jar
> 
> I realize that this is somewhat of a rare issue, but I typically only use the CLI when using Okta as I usually don't have a need to sign in to the web panel often. If this isn't something that can necessarily be resolved, then I totally understand. As always, feel free to let me know if I can provide any additional information. Thanks! :)

Solution
--------
 - Present clear error when password is expired

 - Present password expiration warning if configured in Okta

 - Present clear error on unsupported/undocumented states

Resolves #249