### PR TITLE
Improve install script

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -40,11 +40,13 @@ This tool has been verified to work on macOS Sierra, High Sierra, Windows Server
 
 ### macOS/Linux
 
-1. Run the following in a Terminal:
+1. Run the following in a Terminal, optionally setting a custom
+   `PREFIX` value (default: `~/.okta`):
+
     ```bash
-    export PREFIX=/usr/local
-    curl 'https://raw.githubusercontent.com/oktadeveloper/okta-aws-cli-assume-role/master/bin/install.sh' | bash
+    PREFIX=~/.okta bash <(curl -fsSL 'https://raw.githubusercontent.com/oktadeveloper/okta-aws-cli-assume-role/master/bin/install.sh) -i
     ```
+
 2. Customize **~/.okta/config.properties** and set **OKTA_ORG** and **OKTA_AWS_APP_URL** appropriately. For example,
    
    ```properties

--- a/Readme.MD
+++ b/Readme.MD
@@ -44,7 +44,7 @@ This tool has been verified to work on macOS Sierra, High Sierra, Windows Server
    `PREFIX` value (default: `~/.okta`):
 
     ```bash
-    PREFIX=~/.okta bash <(curl -fsSL 'https://raw.githubusercontent.com/oktadeveloper/okta-aws-cli-assume-role/master/bin/install.sh) -i
+    PREFIX=~/.okta bash <(curl -fsSL https://raw.githubusercontent.com/oktadeveloper/okta-aws-cli-assume-role/master/bin/install.sh) -i
     ```
 
 2. Customize **~/.okta/config.properties** and set **OKTA_ORG** and **OKTA_AWS_APP_URL** appropriately. For example,

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -129,3 +129,9 @@ OKTA_USERNAME=$env:USERNAME
 OKTA_BROWSER_AUTH=true
 EOF
 fi
+cat <<EOF | sed "s#$HOME#~#g"
+Customize ${oktaConfig} and verify your setup with:
+
+    okta-aws test sts get-caller-identity
+
+EOF

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -196,7 +196,6 @@ if [[ -d "${PREFIX}/bin" && ":\$PATH:" != *":${PREFIX}/bin:"* ]]; then
 fi
 EOF
 )
-eval "$shellstmt"
 echo
 echo "Add the following to ~/.bash_profile or ~/.profile:"
 echo

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -56,7 +56,7 @@ fi
 echo
 echo "Add the following to ~/.bash_profile or ~/.profile:"
 echo
-cat <<EOF
+cat <<EOF | sed "s#$HOME#\$HOME#g"
 #OktaAWSCLI
 if [ -f "${bash_functions}" ]; then
     . "${bash_functions}"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -47,7 +47,7 @@ EOF
 fi
 
 # Create fish shell functions
-fishFunctionsDir="${HOME}/.config/fish/functions"
+fishFunctionsDir="${dotokta}/fish_functions"
 mkdir -p "${fishFunctionsDir}"
 cat <<'EOF' >"${fishFunctionsDir}/okta-aws.fish"
 function okta-aws

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-dotokta=${PREFIX:=~/.okta}
 repo_url="https://github.com/oktadeveloper/okta-aws-cli-assume-role"
+dotokta=${PREFIX:=~/.okta}
+
+echo "Installing into ${dotokta}..."
 
 if ! java -version &>/dev/null; then
     echo "Warning: Java is not installed. Make sure to install that" >&2
@@ -27,8 +29,10 @@ fi
 mkdir -p ${dotokta}
 releaseUrl=$(curl --head --silent ${repo_url}/releases/latest | grep "Location:" | cut -c11-)
 releaseTag=$(echo $releaseUrl | awk 'BEGIN{FS="/"}{print $8}' | tr -d '\r')
-curl -L "${repo_url}/releases/download/${releaseTag}/okta-aws-cli-${releaseTag:1}.jar" \
-     --output "${dotokta}/okta-aws-cli.jar"
+url="${repo_url}/releases/download/${releaseTag}/okta-aws-cli-${releaseTag:1}.jar"
+dest="${dotokta}/okta-aws-cli.jar"
+echo "Fetching ${url} → ${dest}"
+curl -L "${url}" --output "${dest}"
 
 # bash functions
 bash_functions="${dotokta}/bash_functions"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -17,7 +17,7 @@
 repo_url="https://github.com/oktadeveloper/okta-aws-cli-assume-role"
 dotokta=${PREFIX:=~/.okta}
 
-echo "Installing into ${dotokta}..."
+echo "Installing into ${dotokta}"
 
 if ! java -version &>/dev/null; then
     echo "Warning: Java is not installed. Make sure to install that" >&2
@@ -29,10 +29,14 @@ fi
 mkdir -p ${dotokta}
 releaseUrl=$(curl --head --silent ${repo_url}/releases/latest | grep "Location:" | cut -c11-)
 releaseTag=$(echo $releaseUrl | awk 'BEGIN{FS="/"}{print $8}' | tr -d '\r')
-url="${repo_url}/releases/download/${releaseTag}/okta-aws-cli-${releaseTag:1}.jar"
-dest="${dotokta}/okta-aws-cli.jar"
+url=${repo_url}/releases/download/${releaseTag}/okta-aws-cli-${releaseTag:1}.jar
+dest=${dotokta}/$(basename ${url})
 echo "Fetching ${url} → ${dest}"
 curl -L "${url}" --output "${dest}"
+
+jarpath="${dotokta}/okta-aws-cli.jar"
+echo "Symlinking ${jarpath} → $(basename ${dest})"
+ln -s $(basename ${dest}) "${jarpath}"
 
 # bash functions
 bash_functions="${dotokta}/bash_functions"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -36,6 +36,7 @@ curl -L "${repo_url}/releases/download/${releaseTag}/okta-aws-cli-${releaseTag:1
 bash_functions="${dotokta}/bash_functions"
 if ! grep '^#OktaAWSCLI' "${bash_functions}" &>/dev/null; then
     cat <<'EOF' >>"${bash_functions}"
+#OktaAWSCLI
 function okta-aws {
     withokta "aws --profile $1" $@
 }

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -16,71 +16,70 @@
 #
 PREFIX=${PREFIX:=/usr/local}
 
-java -version > /dev/null 2>&1
-if [ $? -ne 0 ];
-then
-    echo 'Warning: Java is not installed. Make sure to install that'
+dotokta=${HOME}/.okta
+repo_url="https://github.com/oktadeveloper/okta-aws-cli-assume-role"
+
+if ! java -version &>/dev/null; then
+    echo "Warning: Java is not installed. Make sure to install that" >&2
 fi
-aws --version > /dev/null 2>&1
-if [ $? -ne 0 ];
-then
-    echo 'Warning: AWS CLI is not installed. Make sure to install that'
+if ! aws --version &>/dev/null; then
+    echo "Warning: AWS CLI is not installed. Make sure to install that" >&2
 fi
 
-mkdir -p ${HOME}/.okta
-releaseUrl=$(curl --head --silent https://github.com/oktadeveloper/okta-aws-cli-assume-role/releases/latest | grep 'Location:' | cut -c11-)
+mkdir -p ${dotokta}
+releaseUrl=$(curl --head --silent ${repo_url}/releases/latest | grep "Location:" | cut -c11-)
 releaseTag=$(echo $releaseUrl | awk 'BEGIN{FS="/"}{print $8}' | tr -d '\r')
-curl -L "https://github.com/oktadeveloper/okta-aws-cli-assume-role/releases/download/${releaseTag}/okta-aws-cli-${releaseTag:1}.jar" --output "${HOME}/.okta/okta-aws-cli.jar"
+curl -L "${repo_url}/releases/download/${releaseTag}/okta-aws-cli-${releaseTag:1}.jar" \
+     --output "${dotokta}/okta-aws-cli.jar"
 
 # bash functions
-bash_functions="${HOME}/.okta/bash_functions"
-grep '^#OktaAWSCLI' "${bash_functions}" > /dev/null 2>&1
-if [ $? -ne 0 ]
-then
-echo '
+bash_functions="${dotokta}/bash_functions"
+if ! grep '^#OktaAWSCLI' "${bash_functions}" &>/dev/null; then
+    cat <<'EOF' >>"${bash_functions}"
 function okta-aws {
     withokta "aws --profile $1" $@
 }
 function okta-sls {
     withokta "sls --stage $1" $@
 }
-' >> "${bash_functions}"
+EOF
 fi
 
 # Create fish shell functions
 fishFunctionsDir="${HOME}/.config/fish/functions"
 mkdir -p "${fishFunctionsDir}"
-echo '
+cat <<'EOF' >"${fishFunctionsDir}/okta-aws.fish"
 function okta-aws
     withokta "aws --profile $argv[1]" $argv
 end
-' > "${fishFunctionsDir}/okta-aws.fish"
-echo '
+EOF
+cat <<'EOF' >"${fishFunctionsDir}/okta-sls.fish"
 function okta-sls
     withokta "sls --stage $argv[1]" $argv
 end
-' >> "${fishFunctionsDir}/okta-sls.fish"
+EOF
 
 # Conditionally update bash profile
 bashProfile="${HOME}/.bash_profile"
-grep '^#OktaAWSCLI' "${bashProfile}" > /dev/null 2>&1
-if [ $? -ne 0 ]
-then
-echo "
+if ! grep '^#OktaAWSCLI' "${bashProfile}" &>/dev/null; then
+    cat <<EOF >>"${bashProfile}"
 #OktaAWSCLI
-if [ -f \"${bash_functions}\" ]; then
-    . \"${bash_functions}\"
+if [ -f "${bash_functions}" ]; then
+    . "${bash_functions}"
 fi
-" >> "${bashProfile}"
+EOF
 fi
 
-# Suppress "Your profile name includes a 'profile ' prefix" warnings from AWS Java SDK (Resolves #233)
-loggingProperties="${HOME}/.okta/logging.properties"
-echo "com.amazonaws.auth.profile.internal.BasicProfileConfigLoader = NONE
-" > "${loggingProperties}"
+# Suppress "Your profile name includes a 'profile ' prefix" warnings
+# from AWS Java SDK (Resolves #233)
+loggingProperties="${dotokta}/logging.properties"
+cat <<EOF >"${loggingProperties}"
+com.amazonaws.auth.profile.internal.BasicProfileConfigLoader = NONE
+EOF
 
 # Create withokta command
-echo '#!/bin/bash
+cat <<'EOF' >"${PREFIX}/bin/withokta"
+#!/bin/bash
 command="$1"
 profile=$2
 shift;
@@ -89,34 +88,34 @@ env OKTA_PROFILE=$profile java \
     -Djava.util.logging.config.file=~/.okta/logging.properties \
     -classpath ~/.okta/okta-aws-cli.jar \
     com.okta.tools.WithOkta $command $@
-' > "$PREFIX/bin/withokta"
-chmod +x "$PREFIX/bin/withokta"
+EOF
+chmod +x "${PREFIX}/bin/withokta"
 
 # Create okta-credential_process command
-echo '#!/bin/bash
+cat <<'EOF' >"${PREFIX}/bin/okta-credential_process"
+#!/bin/bash
 roleARN="$1"
 shift;
 env OKTA_AWS_ROLE_TO_ASSUME="$roleARN" \
     java -classpath ~/.okta/okta-aws-cli.jar com.okta.tools.CredentialProcess
-' > "$PREFIX/bin/okta-credential_process"
-chmod +x "$PREFIX/bin/okta-credential_process"
+EOF
+chmod +x "${PREFIX}/bin/okta-credential_process"
 
 # Create okta-listroles command
-echo '#!/bin/bash
+cat <<EOF >"${PREFIX}/bin/okta-listroles"
+#!/bin/bash
 java -classpath ~/.okta/okta-aws-cli.jar com.okta.tools.ListRoles
-' > "$PREFIX/bin/okta-listroles"
-chmod +x "$PREFIX/bin/okta-listroles"
+EOF
+chmod +x "${PREFIX}/bin/okta-listroles"
 
 # Configure Okta AWS CLI
-oktaConfig="${HOME}/.okta/config.properties"
-grep '^#OktaAWSCLI' "${oktaConfig}" > /dev/null 2>&1
-if [ $? -ne 0 ]
-then
-echo "
+oktaConfig="${dotokta}/config.properties"
+if ! grep '^#OktaAWSCLI' "${oktaConfig}" &>/dev/null; then
+    cat <<EOF >"${oktaConfig}"
 #OktaAWSCLI
 OKTA_ORG=acmecorp.okta.com.changeme.local
 OKTA_AWS_APP_URL=https://acmecorp.oktapreview.com.changeme.local/home/amazon_aws/0oa5zrwfs815KJmVF0h7/137
 OKTA_USERNAME=$env:USERNAME
 OKTA_BROWSER_AUTH=true
-" > "${oktaConfig}"
+EOF
 fi

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -14,9 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-PREFIX=${PREFIX:=/usr/local}
-
-dotokta=${HOME}/.okta
+dotokta=${PREFIX:=~/.okta}
 repo_url="https://github.com/oktadeveloper/okta-aws-cli-assume-role"
 
 if ! java -version &>/dev/null; then
@@ -47,6 +45,7 @@ EOF
 fi
 
 # Print advice for ~/.bash_profile
+echo
 echo "Add the following to ~/.bash_profile or ~/.profile:"
 echo
 cat <<EOF
@@ -55,6 +54,7 @@ if [ -f "${bash_functions}" ]; then
     . "${bash_functions}"
 fi
 EOF
+echo
 
 # Create fish shell functions
 fishFunctionsDir="${dotokta}/fish_functions"
@@ -77,8 +77,10 @@ cat <<EOF >"${loggingProperties}"
 com.amazonaws.auth.profile.internal.BasicProfileConfigLoader = NONE
 EOF
 
+mkdir -p "${dotokta}/bin"
+
 # Create withokta command
-cat <<'EOF' >"${PREFIX}/bin/withokta"
+cat <<'EOF' >"${dotokta}/bin/withokta"
 #!/bin/bash
 command="$1"
 profile=$2
@@ -89,24 +91,24 @@ env OKTA_PROFILE=$profile java \
     -classpath ~/.okta/okta-aws-cli.jar \
     com.okta.tools.WithOkta $command $@
 EOF
-chmod +x "${PREFIX}/bin/withokta"
+chmod +x "${dotokta}/bin/withokta"
 
 # Create okta-credential_process command
-cat <<'EOF' >"${PREFIX}/bin/okta-credential_process"
+cat <<'EOF' >"${dotokta}/bin/okta-credential_process"
 #!/bin/bash
 roleARN="$1"
 shift;
 env OKTA_AWS_ROLE_TO_ASSUME="$roleARN" \
     java -classpath ~/.okta/okta-aws-cli.jar com.okta.tools.CredentialProcess
 EOF
-chmod +x "${PREFIX}/bin/okta-credential_process"
+chmod +x "${dotokta}/bin/okta-credential_process"
 
 # Create okta-listroles command
-cat <<EOF >"${PREFIX}/bin/okta-listroles"
+cat <<EOF >"${dotokta}/bin/okta-listroles"
 #!/bin/bash
 java -classpath ~/.okta/okta-aws-cli.jar com.okta.tools.ListRoles
 EOF
-chmod +x "${PREFIX}/bin/okta-listroles"
+chmod +x "${dotokta}/bin/okta-listroles"
 
 # Configure Okta AWS CLI
 oktaConfig="${dotokta}/config.properties"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -58,8 +58,11 @@ echo "Add the following to ~/.bash_profile or ~/.profile:"
 echo
 cat <<EOF | sed "s#$HOME#\$HOME#g"
 #OktaAWSCLI
-if [ -f "${bash_functions}" ]; then
-    . "${bash_functions}"
+if [[ -d ${dotokta} ]]; then
+    if [ -f "${bash_functions}" ]; then
+        . "${bash_functions}"
+    fi
+    PATH="${dotokta}/bin:\$PATH"
 fi
 EOF
 echo
@@ -120,7 +123,10 @@ chmod +x "${dotokta}/bin/okta-listroles"
 
 # Configure Okta AWS CLI
 oktaConfig="${dotokta}/config.properties"
-if ! grep '^#OktaAWSCLI' "${oktaConfig}" &>/dev/null; then
+if [[ -e "${oktaConfig}" ]]; then
+    echo "Found $(echo ${oktaConfig} | sed "s#$HOME#~#g")"
+else
+    echo "Creating example $(echo ${oktaConfig} | sed "s#$HOME#~#g")"
     cat <<EOF >"${oktaConfig}"
 #OktaAWSCLI
 OKTA_ORG=acmecorp.okta.com.changeme.local
@@ -129,9 +135,10 @@ OKTA_USERNAME=$env:USERNAME
 OKTA_BROWSER_AUTH=true
 EOF
 fi
+echo
 cat <<EOF | sed "s#$HOME#~#g"
 Customize ${oktaConfig} and verify your setup with:
 
-    okta-aws test sts get-caller-identity
+    okta-aws PROFILE_NAME sts get-caller-identity
 
 EOF

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -46,6 +46,16 @@ function okta-sls {
 EOF
 fi
 
+# Print advice for ~/.bash_profile
+echo "Add the following to ~/.bash_profile or ~/.profile:"
+echo
+cat <<EOF
+#OktaAWSCLI
+if [ -f "${bash_functions}" ]; then
+    . "${bash_functions}"
+fi
+EOF
+
 # Create fish shell functions
 fishFunctionsDir="${dotokta}/fish_functions"
 mkdir -p "${fishFunctionsDir}"
@@ -59,17 +69,6 @@ function okta-sls
     withokta "sls --stage $argv[1]" $argv
 end
 EOF
-
-# Conditionally update bash profile
-bashProfile="${HOME}/.bash_profile"
-if ! grep '^#OktaAWSCLI' "${bashProfile}" &>/dev/null; then
-    cat <<EOF >>"${bashProfile}"
-#OktaAWSCLI
-if [ -f "${bash_functions}" ]; then
-    . "${bash_functions}"
-fi
-EOF
-fi
 
 # Suppress "Your profile name includes a 'profile ' prefix" warnings
 # from AWS Java SDK (Resolves #233)

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -116,7 +116,8 @@ EOF
 chmod +x "${dotokta}/bin/awscli"
 
 # Configure Okta AWS CLI
-oktaConfig="${dotokta}/config.properties"
+mkdir -p ${HOME}/.okta                       # `config.properties` must
+oktaConfig="${HOME}/.okta/config.properties" # reside in ~/.okta.
 if [[ -e "${oktaConfig}" ]]; then
     echo "Found $(echo ${oktaConfig} | sed "s#$HOME#~#g")"
 else

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -121,6 +121,15 @@ java -classpath ~/.okta/okta-aws-cli.jar com.okta.tools.ListRoles
 EOF
 chmod +x "${dotokta}/bin/okta-listroles"
 
+# awscli
+cat <<'EOF' >"${dotokta}/bin/awscli"
+#!/bin/bash
+java -Djava.util.logging.config.file=~/.okta/logging.properties \
+     -classpath ~/.okta/okta-aws-cli.jar \
+     com.okta.tools.awscli $@
+EOF
+chmod +x "${dotokta}/bin/awscli"
+
 # Configure Okta AWS CLI
 oktaConfig="${dotokta}/config.properties"
 if [[ -e "${oktaConfig}" ]]; then


### PR DESCRIPTION
Problem Statement
-----------------

Install script is (1) difficult to read, (2) does not print critical information about what it is doing, (3) silently modifies `~/.bash_profile`, and (4) writes files to multiple locations in the filesystem, a change that is difficult to revert unless there is a corresponding uninstallation mechanism.


Solution
--------

1. Update the install script to make it easier to read using here documents
2. Print information about what it is doing
3. Print advice about how to modify `~/.bash_profile` and how to proceed post-installation
4. Write all files to `~/.okta` so that uninstalling only involves removing that directory