### PR TITLE
Feature/authn-error-handling-during-browser-flow

### DIFF
--- a/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
+++ b/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
@@ -67,6 +67,12 @@ public final class BrowserAuthentication extends Application {
                         stage.setTitle(webEngine.getLocation());
                     }
                 });
+
+        webEngine.getLoadWorker().exceptionProperty()
+            .addListener((ov, oldState, newState) -> {
+                System.out.format("exception(%s => %s)\n%s\n", oldState, newState, webEngine.getLoadWorker().getException());
+            });
+
         webEngine.load(uri.toASCIIString());
 
         scene.setRoot(scrollPane);


### PR DESCRIPTION
(Edited for rebasing)

Problem Statement
-----------------
If the runtime environment is missing a certificate, the Okta dialog would popup and hang with no feedback (SSL handshake failure).

Solution
--------
Add an error property change listener to print error message for User (could throw Exception if wouldn't disrupt other workflows)

