### PR TITLE
:hammer: JAR manifest including version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,18 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.1</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.0</version>
                 <configuration>


### PR DESCRIPTION
Problem Statement
-----------------
It is not practical to determine what version of this is in use when troubleshooting.

Solution
--------
 - Include implementation entries in JAR manifest

Existing META-INF/MANIFEST.MF looks like this:
```
Manifest-Version: 1.0
Archiver-Version: Plexus Archiver
Created-By: Apache Maven
Built-By: alain.odea
Build-Jdk: 11.0.1
```

Add these entries to the above (auto-generated):
```
Implementation-Title: okta-aws-cli
Implementation-Version: 1.0.9-SNAPSHOT
Implementation-Vendor-Id: com.okta.developer
Main-Class: com.okta.tools.awscli
```

