### PR TITLE
:bug: SRI hack doesn't work for multi-org

### DIFF
--- a/src/main/java/com/okta/tools/io/LoginPageInterceptingProtocolHandler.java
+++ b/src/main/java/com/okta/tools/io/LoginPageInterceptingProtocolHandler.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.BiFunction;
 import java.util.logging.Logger;
 
@@ -24,12 +25,18 @@ final class LoginPageInterceptingProtocolHandler extends sun.net.www.protocol.ht
     @Override
     protected URLConnection openConnection(URL url, Proxy proxy) throws IOException {
         URLConnection urlConnection = super.openConnection(url, proxy);
-        if (environment.oktaOrg.equals(url.getHost()) &&
-            Arrays.asList(
-                    URI.create(environment.oktaAwsAppUrl).getPath(),
-                    "/login/login.htm",
-                    "/auth/services/devicefingerprint"
-            ).contains(url.getPath())
+        URI oktaAwsAppUri = URI.create(environment.oktaAwsAppUrl);
+        List<String> domainsToIntercept = Arrays.asList(
+                environment.oktaOrg,
+                oktaAwsAppUri.getHost()
+        );
+        List<String> requestPathsToIntercept = Arrays.asList(
+                oktaAwsAppUri.getPath(),
+                "/login/login.htm",
+                "/auth/services/devicefingerprint"
+        );
+        if (domainsToIntercept.contains(url.getHost()) &&
+            requestPathsToIntercept.contains(url.getPath())
         ) {
             LOGGER.finest(() -> String.format("[%s] Using filtering URLConnection", url));
             return filteringUrlConnectionFactory.apply(url, urlConnection);


### PR DESCRIPTION
Problem Statement
-----------------
Issue #276 states:

> I just re-tested and it works for me without the warning messages.
> 
> I can get it to display a blank screen if I change the config so that the OKTA_ORG and OKTA_AWS_APP_URL are different domains - i.e. this does NOT work now (but it did up until last week):
> 
> OKTA_ORG=https://[corporate-okta-url-1]
> OKTA_AWS_APP_URL=https://[corporate-okta-url-2]/home/amazon_aws/[blah blah]
> 
> but if the org and aws url use the same domain it DOES work (up until the most recent 1.0.9 build this printed some errors to the command window) - i.e.
> 
> OKTA_ORG=https://[corporate-okta-url-1]
> OKTA_AWS_APP_URL=https://[corporate-okta-url-1]/home/amazon_aws/[blah blah]
> 
> _Originally posted by @mrbelowski in [#272 (comment)](https://github.com/oktadeveloper/okta-aws-cli-assume-role/issues/272#issuecomment-467413639)_

Solution
--------
 - Strip SRI from both app URL and Org domains

Resolves #276

