### PR TITLE
:bug: withokta aliased to listroles on Windows

### DIFF
--- a/bin/Install-OktaAwsCli.ps1
+++ b/bin/Install-OktaAwsCli.ps1
@@ -102,7 +102,7 @@ function Invoke-Okta {
         $env:OKTA_PROFILE = $OriginalOKTA_PROFILE
     }
 }
-New-Alias -Name withokta -value Get-OktaRoles
+New-Alias -Name withokta -value Invoke-Okta
 New-Alias -Name with-okta -value Invoke-Okta
 
 function Get-OktaRoles {


### PR DESCRIPTION
Problem Statement
-----------------
Issue #281 states:
> **Describe the bug**
> The withokta alias is bound to the wrong Cmdlet (Get-OktaRoles) here:
> 
> [okta-aws-cli-assume-role/bin/Install-OktaAwsCli.ps1](https://github.com/oktadeveloper/okta-aws-cli-assume-role/blob/7e1ad72f96a0dbbf752bd11904135fb0a3eba3a2/bin/Install-OktaAwsCli.ps1#L105)
> 
> Line 105 in [7e1ad72](/oktadeveloper/okta-aws-cli-assume-role/commit/7e1ad72f96a0dbbf752bd11904135fb0a3eba3a2)
>  New-Alias -Name withokta -value Get-OktaRoles 
> 
> **To Reproduce**
> Run withokta default aws sts get-caller-identity
> 
> **Expected behavior**
> aws sts get-caller-identity is called after populating the default profile with credentials from Okta.
> 
> **Screenshots**
> N/A
> 
> **Additional context**
> Affects all releases v1.0.7 through v1.0.10 (including master at this time of writing)


Solution
--------
 - alias withokta to Invoke-Okta as intended

Resolves #281

