### PR TITLE
Remove duplicate okta-aws function in install script

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -100,9 +100,6 @@ if ! grep '^#OktaAWSCLI' "${bash_functions}" &>/dev/null; then
 function okta-aws {
     withokta "aws --profile $1" $@
 }
-function okta-aws {
-    withokta "aws --profile $1" $@
-}
 function okta-sls {
     withokta "sls --stage $1" $@
 }


### PR DESCRIPTION
Problem Statement
-----------------
Seems like a copy pasta mistake in the install script creating two of the same functions. 


Solution
--------
Remove one of them!

