### PR TITLE
Update jar symlink even if it already exists

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -90,7 +90,7 @@ curl -Ls -o "${dest}" "${url}"
 
 jarpath="${PREFIX}/okta-aws-cli.jar"
 echo "Symlinking ${jarpath} → $(basename ${dest})" | sed "s#$HOME#~#g"
-ln -s $(basename ${dest}) "${jarpath}"
+ln -sf $(basename ${dest}) "${jarpath}"
 
 # bash functions
 bash_functions="${PREFIX}/bash_functions"


### PR DESCRIPTION
- It seems like the `bin/install.sh` script is supposed to be able to be used to upgrade an existing installation
  since it will leave existing configuration files in place if they already exist; however, it fails to actually upgrade
  because it does not update the `okta-aws-cli.jar` symlink to point to the new version of the JAR file since it is
  not passing the `-f` flag to `ln`. This adds the `-f` flag to that `ln` call.

Problem Statement
-----------------



Solution
--------


