### PR TITLE
fix browser auth issue, multiple roles, and make role to assume more flexible

### DIFF
--- a/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
+++ b/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
@@ -128,7 +128,7 @@ public final class BrowserAuthentication extends Application {
                 Node formActionAttribute = formAttributes.getNamedItem("action");
                 if (formActionAttribute != null) {
                     String formAction = formActionAttribute.getTextContent();
-                    if ("https://signin.aws.amazon.com/saml".equals(formAction)) {
+                    if (formAction.endsWith("/saml")) {
                         return form;
                     }
                 }

--- a/src/main/java/com/okta/tools/helpers/RoleHelper.java
+++ b/src/main/java/com/okta/tools/helpers/RoleHelper.java
@@ -77,7 +77,8 @@ public class RoleHelper {
                 for (RoleOption roleOption : accountOption.roleOptions) {
                     roleArns.add(roleOption.roleArn);
                     System.err.println("\t[ " + (i + 1) + " ]: " + roleOption.roleName);
-                    if (roleOption.roleArn.equals(environment.awsRoleToAssume)) {
+                    if (roleOption.roleArn.equals(environment.awsRoleToAssume) ||
+                        roleOption.roleName.equals(environment.awsRoleToAssume)) {
                         j = i;
                     }
                     i++;
@@ -120,7 +121,7 @@ public class RoleHelper {
     public List<AccountOption> getAvailableRoles(String samlResponse) throws IOException {
         Map<String, String> roles = AwsSamlRoleUtils.getRoles(samlResponse);
         if (roles.size() == 1) {
-            String roleArn = roles.values().iterator().next();
+            String roleArn = roles.keySet().iterator().next();
             return Collections.singletonList(
                     new AccountOption("Account:  (" + roleArn.substring("arn:aws:iam::".length(), "arn:aws:iam::".length() + 12) + ")",
                             Collections.singletonList(

--- a/src/main/java/com/okta/tools/saml/AwsSamlRoleUtils.java
+++ b/src/main/java/com/okta/tools/saml/AwsSamlRoleUtils.java
@@ -46,7 +46,7 @@ public final class AwsSamlRoleUtils {
             String[] parts = roleIdpPair.split(",");
             String principalArn = parts[0];
             String roleArn = parts[1];
-            roles.put(principalArn, roleArn);
+            roles.put(roleArn, principalArn);
         }
         return roles;
     }


### PR DESCRIPTION
Problem Statement
-----------------
- The javafx window remains open and never shuts down once user authenticates (https://github.com/oktadeveloper/okta-aws-cli-assume-role/issues/317)
- Multiple roles are not handles correctly due to order of roleArn and principal being incorrect in map (this reverts previous change https://github.com/oktadeveloper/okta-aws-cli-assume-role/commit/ecbf26ecd2b0b460496cb9131ec8f5202cab421b#diff-13509f60aa8d183ec80dc2582dc38e74R49)
- I would like more flexibility for the OKTA_AWS_ROLE_TO_ASSUME env variable to be a full arn or just a name since in my scenario we are wrapping this tool and supporting multiple accounts and roles

Solution
--------
- check for relative path in form /saml
- fix order of role arn map
- modify code that selects role to check OKTA_AWS_ROLE_TO_ASSUME match on role arn or role name


