### PR TITLE
 🐛 Inherit input and error streams for password command

### DIFF
--- a/src/main/java/com/okta/tools/OktaAwsConfig.java
+++ b/src/main/java/com/okta/tools/OktaAwsConfig.java
@@ -87,6 +87,8 @@ final class OktaAwsConfig {
         } else if (SystemUtils.IS_OS_UNIX) {
             processBuilder.command("sh", "-c", oktaPasswordCommand);
         }
+        processBuilder.redirectInput(ProcessBuilder.Redirect.INHERIT);
+        processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
         try {
             Process passwordCommandProcess = processBuilder.start();
             String password = getOutput(passwordCommandProcess);


### PR DESCRIPTION
Problem Statement
-----------------

- After setting up `OKTA_PASSWORD_CMD` to use `lpass show --password okta.com`, I noticed that if the LastPass CLI needed to reprompt for my LastPass master password, it was failing and the Okta AWS CLI was swallowing any error messages.

Solution
--------

- Inheriting the error stream means that the password command's error message will actually show up and inheriting the input stream allows the password command to prompt for anything it needs such as the LastPass CLI. This leaves standard output as a pipe since that is what is used to retrieve the password as usual.
