### PR TITLE
 🐛 Only remove --profile arg when in OKTA_ENV_MODE

### DIFF
--- a/src/main/java/com/okta/tools/WithOkta.java
+++ b/src/main/java/com/okta/tools/WithOkta.java
@@ -34,9 +34,9 @@ public class WithOkta {
             awsEnvironment.put("AWS_ACCESS_KEY_ID", runResult.accessKeyId);
             awsEnvironment.put("AWS_SECRET_ACCESS_KEY", runResult.secretAccessKey);
             awsEnvironment.put("AWS_SESSION_TOKEN", runResult.sessionToken);
+            // Cleanup command line arguments if present
+            args = removeProfileArguments(args);
         }
-        // Cleanup command line arguments if present
-        args = removeProfileArguments(args);
 
         if(args.length == 0) {
             logger.info("No additional command line arguments provided. Hint: okta-aws <aws cli command>");
@@ -61,6 +61,8 @@ public class WithOkta {
             else if (profileArg) {
                 // skip the profile argument
                 profileArg = false;
+            } else if (arg.startsWith("--profile=")) {
+              // skip the single argument profile flag
             } else {
                 argsList.add(arg);
             }


### PR DESCRIPTION

Problem Statement
-----------------

- With #303, the call to `removeProfileArguments` moved out of only OKTA_ENV_MODE. I don't think this is correct since it was specifically added in #185 which added OKTA_ENV_MODE.

Solution
--------

- I have moved the call to `removeProfileArguments` back to only the OKTA_ENV_MODE execution path.
- I have also added support for removing `--profile=*` arguments as well since that is also a valid use of the `aws` CLI.