### PR TITLE
Fix 'awscli logout' command

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -136,7 +136,7 @@ command="$1"
 profile=$2
 shift;
 shift;
-if [ "$3" == "logout" ]
+if [ "$1" == "logout" ]
 then
     command="logout"
 fi


### PR DESCRIPTION
Problem Statement
-----------------
You cannot logout from your AWS account using 'awscli logout' command.


Solution
--------
Fix the argument management on 'withokta' script
