### PR TITLE
Fix Okta Push polling exception

### DIFF
--- a/src/main/java/com/okta/tools/helpers/HttpHelper.java
+++ b/src/main/java/com/okta/tools/helpers/HttpHelper.java
@@ -15,9 +15,7 @@
  */
 package com.okta.tools.helpers;
 
-import com.amazonaws.RequestConfig;
 import org.apache.http.HttpHost;
-import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.socket.ConnectionSocketFactory;

--- a/src/main/java/com/okta/tools/helpers/HttpHelper.java
+++ b/src/main/java/com/okta/tools/helpers/HttpHelper.java
@@ -15,7 +15,9 @@
  */
 package com.okta.tools.helpers;
 
+import com.amazonaws.RequestConfig;
 import org.apache.http.HttpHost;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.socket.ConnectionSocketFactory;


### PR DESCRIPTION
Problem Statement
-----------------
A v2.0 code refactor (#280) / cleanup broke a few JSON traversals needed to support Okta MFA

Solution
--------
Reverts broken JSON traversal for the polling URL to prior implementation & short-circuits polling loop on success (at which point `FACTOR_RESULT` no longer exists)

Fixes #316