### PR TITLE
web browser auth single role fix

### DIFF
--- a/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
+++ b/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
@@ -80,8 +80,8 @@ public final class BrowserAuthentication extends Application {
         initializeCookies(uri);
 
         SubresourceIntegrityStrippingHack.overrideHttpsProtocolHandler(environment);
-        webEngine.getLoadWorker().stateProperty()
-                .addListener((ov, oldState, newState) -> {
+        webEngine.locationProperty()
+                .addListener((ov, oldLocation, newLocation) -> {
                     if (webEngine.getDocument() != null) {
                         checkForAwsSamlSignon(stage, webEngine);
                         stage.setTitle(webEngine.getLocation());


### PR DESCRIPTION


Problem Statement
-----------------
When using web browser authentication if there is only one AWS role available to the user AWS returns a 302 and the javafx browser does not see the event. This results in the javafx browser sitting on the logged in AWS console page and never returning.


Solution
--------
Monitor the `locationProperty` for changes instead of the `stateProperty`.

Fixes https://github.com/oktadeveloper/okta-aws-cli-assume-role/issues/328

