### PR TITLE
Modified the install.sh to make the withokta script slightly proxy-aware

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -111,6 +111,10 @@ okta-aws test sts get-caller-identity
 
 NOTE: **okta-aws** is a function loaded from your shell profile, not a typical program or command stored in a file.
 
+NOTE: On a *nix platform the `withokta` wrapper script will attempt to parse `$https_proxy` as a URI. If successful the host and port values will be passed to the JVM. User credentials in the proxy configuration are not currently used. This allows the `okta-aws` tool to be used in an environment where internet access for the servers is mediate via a proxy, e.g an EC2 instance inside a restricted VPC.
+
+The proxy URI _must_ be of the form `http://host:port/`. Both the host and port are mandatory.
+
 ## Reference
 * [okta-listroles(1)](docs/man/okta-listroles.1.md)
 * [okta-credential_process(1)](docs/man/okta-credential_process.1.md)

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -140,9 +140,13 @@ if [ "\$3" == "logout" ]
 then
     command="logout"
 fi
-env OKTA_PROFILE=\$profile java \
-    -Djava.util.logging.config.file=${PREFIX}/logging.properties \
-    -classpath ${PREFIX}/okta-aws-cli.jar \
+if [ -n "\$https_proxy" ]; then
+    readonly URI_REGEX='^(([^:/?#]+):)?(//((([^:/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))(\?([^#]*))?(#(.*))?'
+    [[ \$https_proxy =~ \${URI_REGEX} ]] && PROXY_CONFIG="-Dhttps.proxyHost=\${BASH_REMATCH[7]} -Dhttps.proxyPort=\${BASH_REMATCH[9]}"
+fi
+env OKTA_PROFILE=\$profile java \${PROXY_CONFIG} \\
+    -Djava.util.logging.config.file=${PREFIX}/logging.properties \\
+    -classpath ${PREFIX}/okta-aws-cli.jar \\
     com.okta.tools.WithOkta \$command "\$@"
 EOF
 chmod +x "${PREFIX}/bin/withokta"
@@ -152,15 +156,23 @@ cat <<EOF >"${PREFIX}/bin/okta-credential_process"
 #!/bin/bash
 roleARN="\$1"
 shift;
-env OKTA_AWS_ROLE_TO_ASSUME="\$roleARN" \
-    java -classpath ${PREFIX}/okta-aws-cli.jar com.okta.tools.CredentialProcess
+if [ -n "\$https_proxy" ]; then
+    readonly URI_REGEX='^(([^:/?#]+):)?(//((([^:/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))(\?([^#]*))?(#(.*))?'
+    [[ \$https_proxy =~ \${URI_REGEX} ]] && PROXY_CONFIG="-Dhttps.proxyHost=\${BASH_REMATCH[7]} -Dhttps.proxyPort=\${BASH_REMATCH[9]}"
+fi
+env OKTA_AWS_ROLE_TO_ASSUME="\$roleARN" \\
+    java \${PROXY_CONFIG} -classpath ${PREFIX}/okta-aws-cli.jar com.okta.tools.CredentialProcess
 EOF
 chmod +x "${PREFIX}/bin/okta-credential_process"
 
 # Create okta-listroles command
 cat <<EOF >"${PREFIX}/bin/okta-listroles"
 #!/bin/bash
-java -classpath ${PREFIX}/okta-aws-cli.jar com.okta.tools.ListRoles
+if [ -n "\$https_proxy" ]; then
+    readonly URI_REGEX='^(([^:/?#]+):)?(//((([^:/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))(\?([^#]*))?(#(.*))?'
+    [[ \$https_proxy =~ \${URI_REGEX} ]] && PROXY_CONFIG="-Dhttps.proxyHost=\${BASH_REMATCH[7]} -Dhttps.proxyPort=\${BASH_REMATCH[9]}"
+fi
+java \${PROXY_CONFIG} -classpath ${PREFIX}/okta-aws-cli.jar com.okta.tools.ListRoles
 EOF
 chmod +x "${PREFIX}/bin/okta-listroles"
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -130,37 +130,37 @@ EOF
 mkdir -p "${PREFIX}/bin"
 
 # Create withokta command
-cat <<'EOF' >"${PREFIX}/bin/withokta"
+cat <<EOF >"${PREFIX}/bin/withokta"
 #!/bin/bash
-command="$1"
-profile=$2
+command="\$1"
+profile=\$2
 shift;
 shift;
-if [ "$3" == "logout" ]
+if [ "\$3" == "logout" ]
 then
     command="logout"
 fi
-env OKTA_PROFILE=$profile java \
-    -Djava.util.logging.config.file=~/.okta/logging.properties \
-    -classpath ~/.okta/okta-aws-cli.jar \
-    com.okta.tools.WithOkta $command "$@"
+env OKTA_PROFILE=\$profile java \
+    -Djava.util.logging.config.file=${PREFIX}/logging.properties \
+    -classpath ${PREFIX}/okta-aws-cli.jar \
+    com.okta.tools.WithOkta \$command "\$@"
 EOF
 chmod +x "${PREFIX}/bin/withokta"
 
 # Create okta-credential_process command
-cat <<'EOF' >"${PREFIX}/bin/okta-credential_process"
+cat <<EOF >"${PREFIX}/bin/okta-credential_process"
 #!/bin/bash
-roleARN="$1"
+roleARN="\$1"
 shift;
-env OKTA_AWS_ROLE_TO_ASSUME="$roleARN" \
-    java -classpath ~/.okta/okta-aws-cli.jar com.okta.tools.CredentialProcess
+env OKTA_AWS_ROLE_TO_ASSUME="\$roleARN" \
+    java -classpath ${PREFIX}/okta-aws-cli.jar com.okta.tools.CredentialProcess
 EOF
 chmod +x "${PREFIX}/bin/okta-credential_process"
 
 # Create okta-listroles command
 cat <<EOF >"${PREFIX}/bin/okta-listroles"
 #!/bin/bash
-java -classpath ~/.okta/okta-aws-cli.jar com.okta.tools.ListRoles
+java -classpath ${PREFIX}/okta-aws-cli.jar com.okta.tools.ListRoles
 EOF
 chmod +x "${PREFIX}/bin/okta-listroles"
 
@@ -182,7 +182,7 @@ else
 #OktaAWSCLI
 OKTA_ORG=acmecorp.okta.com.changeme.local
 OKTA_AWS_APP_URL=https://acmecorp.oktapreview.com.changeme.local/home/amazon_aws/0oa5zrwfs815KJmVF0h7/137
-OKTA_USERNAME=$env:USERNAME
+OKTA_USERNAME=\$env:USERNAME
 OKTA_BROWSER_AUTH=true
 EOF
 fi


### PR DESCRIPTION
Problem Statement
-----------------
On a corporate managed EC2 instance I had a requirement to run the Okta AWS tools so that I could manipulate and interrogate the infrastructure. The EC2 is deployed into a VPC that mandates the use of a proxy to access the internet.

Java doesn't seem to have an environment-variable-based way of configuring a proxy at runtime.

Solution
--------
It seemed that the most appropriate way to make this work was to modify the wrapper script that calls the `com.okta.tools.WithOkta` class to append the `https.proxyHost` and `https.proxyPort` settings to the java command line.

The change creates a variable called `PROXY_CONFIG` if there is an environment variable named `http_proxy` set to a non-empty value, and it could be parsed by a `bash(1)` regular-expression.

* If the `https_proxy` variable *isn't* set then the `PROXY_CONFIG` value is not created, and the command line continues unaltered.
* If the `https_proxy` is set and the regex match *fails* then the `PROXY_CONFIG` value is not created, and the command line continues unaltered.
* If the `https_proxy` is set and the regex match *succeeds* then the `PROXY_CONFIG` is set with the parsed host and port values, ready to be used in the java command line.
