### PR TITLE
sending region to env mode

### DIFF
--- a/src/main/java/com/okta/tools/WithOkta.java
+++ b/src/main/java/com/okta/tools/WithOkta.java
@@ -34,6 +34,7 @@ public class WithOkta {
             awsEnvironment.put("AWS_ACCESS_KEY_ID", runResult.accessKeyId);
             awsEnvironment.put("AWS_SECRET_ACCESS_KEY", runResult.secretAccessKey);
             awsEnvironment.put("AWS_SESSION_TOKEN", runResult.sessionToken);
+            awsEnvironment.put("AWS_DEFAULT_REGION", environment.awsRegion);
             // Cleanup command line arguments if present
             args = removeProfileArguments(args);
         }


### PR DESCRIPTION
Problem Statement
-----------------
The `AWS_REGION` is not sent to the command that receives the rest of the temporary credentials when `OKTA_ENV_MODE=true`


Solution
--------
Send the value of `OKTA_AWS_REGION` to the `AWS_REGION` variable.
