### PR TITLE
sending region to env mode

### DIFF
--- a/src/main/java/com/okta/tools/WithOkta.java
+++ b/src/main/java/com/okta/tools/WithOkta.java
@@ -34,6 +34,7 @@ public class WithOkta {
             awsEnvironment.put("AWS_ACCESS_KEY_ID", runResult.accessKeyId);
             awsEnvironment.put("AWS_SECRET_ACCESS_KEY", runResult.secretAccessKey);
             awsEnvironment.put("AWS_SESSION_TOKEN", runResult.sessionToken);
+            awsEnvironment.put("AWS_DEFAULT_REGION", environment.awsRegion);
             // Cleanup command line arguments if present
             args = removeProfileArguments(args);
         }


### PR DESCRIPTION
Problem Statement
-----------------
When `OKTA_ENV_MODE=true` the `AWS_DEFAULT_REGION` is always set to us-east-1.  


Solution
--------
Pass `OKTA_AWS_REGION` to `AWS_DEFAULT_REGION`.

