### PR TITLE
Profile is showing up twice

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -98,10 +98,10 @@ if ! grep '^#OktaAWSCLI' "${bash_functions}" &>/dev/null; then
     cat <<'EOF' >>"${bash_functions}"
 #OktaAWSCLI
 function okta-aws {
-    withokta "aws --profile $1" "$@"
+    withokta "aws --profile $1" "${@:2}"
 }
 function okta-sls {
-    withokta "sls --stage $1" "$@"
+    withokta "sls --stage $1" "${@:2}"
 }
 EOF
 fi


### PR DESCRIPTION
Problem Statement
-----------------

```
cat ~/.okta/bash_functions
#OktaAWSCLI
function okta-aws {
    echo "EXECUTING: aws --profile $1 $@"
    withokta "aws --profile $1" $@
}
function okta-sls {
    withokta "sls --stage $1" $@
}
```
Output:
```
nathan.pierce@npierce-mbp  ~  okta-aws default default eks --region "us-west-2" update-kubeconfig --name "auto-eks-buildfleet"
EXECUTING: aws --profile default eks --region us-west-2 update-kubeconfig --name auto-eks-buildfleet
usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
aws: error: argument command: Invalid choice, valid choices are:
```

Solution
--------

Switched $@ out for ${@:2}, so that the first argument is removed.

I had tried shift, but it didn't seem to work (even though it looked like it would):
```
function okta-aws {
    PROFILE=$1
    shift # Remove profile from arguments
    echo "EXECUTING: aws --profile $PROFILE $@"
    withokta "aws --profile $PROFILE" $@
}
```

```
okta-aws default eks --region "us-west-2" update-kubeconfig --name "auto-eks-buildfleet"
EXECUTING: aws --profile default eks --region us-west-2 update-kubeconfig --name auto-eks-buildfleet
usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
aws: error: argument command: Invalid choice, valid choices are:
```

Considerations:

I'm not sure if `${@:2}` is functional in older versions of bash. This might not be as compatible as shift. But again, shift isn't working right for me for some reason. AND, I see we're using :# in other places like `${releaseTag:1}`
