### PR TITLE
Adjust the install script to account for the changing GitHub output

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -80,7 +80,7 @@ PREFIX="$(cd -P -- "${PREFIX}" && pwd)"
 echo "Installing into ${PREFIX}" | sed "s#$HOME#~#g"
 
 mkdir -p ${PREFIX}
-releaseUrl=$(curl --head --silent ${repo_url}/releases/latest | grep "Location:" | cut -c11-)
+releaseUrl=$(curl --head --silent ${repo_url}/releases/latest | grep -i "Location:" | cut -c11-)
 releaseTag=$(echo $releaseUrl | awk 'BEGIN{FS="/"}{print $8}' | tr -d '\r')
 url=${repo_url}/releases/download/${releaseTag}/okta-aws-cli-${releaseTag:1}.jar
 dest=${PREFIX}/$(basename ${url})


### PR DESCRIPTION
If you run the following snippet from your `install.sh`:

`curl --head --silent https://github.com/oktadeveloper/okta-aws-cli-assume-role/releases/latest`

You will notice the "Location" element you look for is now "location". I don't know why the case
changed but it makes the install script break. The output now looks like the following (some elements redacted):

```
date: Fri, 28 Feb 2020 15:49:14 GMT
content-type: text/html; charset=utf-8
server: GitHub.com
status: 302 Found
vary: X-PJAX, Accept-Encoding, Accept, X-Requested-With
location: https://github.com/oktadeveloper/okta-aws-cli-assume-role/releases/tag/v2.0.4
cache-control: no-cache
strict-transport-security: max-age=31536000; includeSubdomains; preload
x-frame-options: deny
x-content-type-options: nosniff
x-xss-protection: 1; mode=block
```

A simple change to `grep` to use the `-i` element will make the search case insensitive and now return what is expected.

https://github.com/jvanzyl/okta-aws-cli-assume-role.git

Problem Statement
-----------------



Solution
--------


