### PR TITLE
:bug: remove warnings about cookie headers

### DIFF
--- a/src/main/java/com/okta/tools/helpers/HttpHelper.java
+++ b/src/main/java/com/okta/tools/helpers/HttpHelper.java
@@ -16,6 +16,8 @@
 package com.okta.tools.helpers;
 
 import org.apache.http.HttpHost;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
@@ -45,12 +47,18 @@ public final class HttpHelper {
         return httpClientBuilder
                 .useSystemProperties()
                 .setConnectionManager(cm)
-                .build();
+                .setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
+                .build()
+                ;
     }
 
     public static CloseableHttpClient createClient()
     {
-        return createClient(HttpClients.custom());
+        return createClient(
+            HttpClients
+                .custom()
+                .setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
+        );
     }
 
     private enum ProxySelectorPlainConnectionSocketFactory implements ConnectionSocketFactory {


### PR DESCRIPTION
Problem Statement
-----------------

Prior to this change, the tool's out-of-box operation would emit warnings about cookie headers, like:

```
Oct 16, 2019 3:29:36 PM org.apache.http.client.protocol.ResponseProcessCookies processCookies
WARNING: Invalid cookie header: "Set-Cookie: Okta_Verify_Autopush_[number]=false;Version=1;Path=/;Max-Age=31536000;Secure;Expires=Thu, 15 Oct 2020 13:29:36 GMT;HttpOnly". Invalid 'expires' attribute: Thu, 15 Oct 2020 13:29:36 GMT
```

These warnings interfered with the output and, therefore, the interaction experience.

Solution
--------

After this change, the warnings are removed, as the HTTP client has been updated to expect cookies in standard format.

Resolves: #352